### PR TITLE
docs: bilingual README + enhanced homepage for star growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,137 +1,145 @@
-# IDaaS 身份即服务 · 一本完整的书
+# IDaaS Book · A Complete Guide to Identity & Access Management
 
-> 从 IAM 基础原理，到 OAuth 2.0 / OIDC / SAML 协议深度解读；从 Keycloak、CAS、Dex 开源方案剖析，到 Kubernetes 生产部署与零信任架构——一本系统讲透「身份即服务」的中文开源技术书。
+> **The most comprehensive Chinese-language technical book on enterprise identity.**
+> From IAM fundamentals and OAuth 2.0 / OIDC / SAML protocol deep-dives to Keycloak, CAS, and Dex production deployments — a systematic guide through the entire identity landscape.
+>
+> 🇨🇳 Written in Chinese · [Read Online →](https://idaas.xlabs.club)
 
-📚 **在线阅读：[idaas.xlabs.club](https://idaas.xlabs.club)**
-
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/l10178/idaas-book/.github%2Fworkflows%2Fgh-pages.yml?label=deploy)](https://github.com/l10178/idaas-book/actions/workflows/gh-pages.yml)
-[![GitHub Repo stars](https://img.shields.io/github/stars/l10178/idaas-book?style=social)](https://github.com/l10178/idaas-book/stargazers)
-[![GitHub contributors](https://img.shields.io/github/contributors/l10178/idaas-book)](https://github.com/l10178/idaas-book/graphs/contributors)
-[![GitHub release](https://img.shields.io/github/v/release/l10178/idaas-book)](https://github.com/l10178/idaas-book/releases/latest)
-[![License: CC BY-NC 4.0](https://img.shields.io/badge/License-CC%20BY--NC%204.0-blue)](https://creativecommons.org/licenses/by-nc/4.0/)
+[![Stars](https://img.shields.io/github/stars/l10178/idaas-book?style=social)](https://github.com/l10178/idaas-book/stargazers)
+[![Deploy](https://img.shields.io/github/actions/workflow/status/l10178/idaas-book/.github%2Fworkflows%2Fgh-pages.yml?label=deploy)](https://github.com/l10178/idaas-book/actions/workflows/gh-pages.yml)
+[![Contributors](https://img.shields.io/github/contributors/l10178/idaas-book)](https://github.com/l10178/idaas-book/graphs/contributors)
+[![License](https://img.shields.io/badge/License-CC%20BY--NC%204.0-blue)](https://creativecommons.org/licenses/by-nc/4.0/)
+[![Release](https://img.shields.io/github/v/release/l10178/idaas-book)](https://github.com/l10178/idaas-book/releases/latest)
 
 ---
 
-## 为什么读这本书
+## Why This Book
 
-身份认证与授权，是几乎所有现代应用都绕不开、却又最容易踩坑的底层基础设施。从一次登录到跨域联邦，从一条 Token 到零信任边界，「身份」已经从单纯的账号密码，演化为整个安全体系的控制平面。
+Identity is the control plane of modern systems. Every application needs authentication, authorization, SSO, and audit — yet most teams learn these protocols the hard way: scattered docs, outdated blog posts, and vendor-specific manuals that never explain *why*.
 
-市面上的资料要么零散停留在协议规范，要么只聚焦于某个开源产品的使用手册，缺少一份**把原理、协议、工程实践与前沿趋势串联起来**的系统性中文资料。本书试图填补这个空白：
+This book fills the gap: **a single, coherent Chinese-language resource that connects principles, protocols, engineering practice, and emerging trends in enterprise identity.**
 
-- **既讲 What，也讲 Why**——不止罗列协议字段，更剖析设计哲学与权衡。
-- **既讲原理，也讲落地**——每章配合代码示例、架构图与配置片段。
-- **既讲单点方案，也讲选型决策**——对比 Keycloak / CAS / Dex / Casdoor 等主流方案，给出决策框架。
+| You need... | This book delivers |
+|-------------|-------------------|
+| Protocol deep-dives | OAuth 2.0 / 2.1, OIDC, SAML 2.0, LDAP, SCIM — with security boundaries, common pitfalls, and real-world flows |
+| Engineering recipes | Keycloak Operator, Helm charts, reverse proxy configs, HA setups, monitoring — copy-paste ready |
+| Decision frameworks | Keycloak vs CAS vs Dex vs Casdoor — side-by-side comparison with selection criteria |
+| Architecture patterns | Gateway integration, BFF, Sidecar, multi-tenant account design, federation topologies |
+| Future-proof knowledge | Zero Trust, DID/VC, ReBAC, Passkey/WebAuthn — standalone chapters, not footnotes |
 
-## 适合谁读
+## What's Inside
 
-- 🆕 **IDaaS / IAM 初学者**：想建立完整的身份领域知识体系
-- 🧑‍💻 **后端与平台工程师**：正在接入 SSO、OAuth、OIDC，需要理解协议细节
-- 🏗️ **架构师 / 技术负责人**：要做身份中台选型、生产部署与安全合规决策
-- 🔐 **安全工程师**：关注零信任、MFA、授权模型与审计合规
+**5 parts, 24 chapters, ~130k Chinese characters**, plus a glossary.
 
-## 内容结构
-
-全书共 **5 个部分、24 章、约 13 万字**，附术语速查表。
-
-| 部分 | 章节 | 关键词 |
-|------|------|--------|
-| 📘 第一部分：IDaaS 基础 | 第 1–4 章 | 定义与演进、IAM 核心理念、AuthN vs AuthZ、身份生命周期 |
-| 📗 第二部分：协议与标准 | 第 5–9 章 | OAuth 2.0、OpenID Connect、SAML 2.0、LDAP、SCIM |
-| 📙 第三部分：核心能力 | 第 10–13 章 | SSO、MFA、身份联邦与代理、审计与合规 |
-| 📕 第四部分：实现与实践 | 第 14–19 章 | Keycloak、Apereo CAS、Dex、方案对比、集成模式、K8s 部署 |
-| 📓 第五部分：高级主题 | 第 20–24 章 | 授权模型（RBAC/ABAC/ReBAC）、安全实践、性能扩展、去中心化身份、零信任 |
-| 📎 附录 | — | IDaaS 核心术语速查表 |
-
-### 章节速览
+| Part | Chapters | Covers |
+|------|----------|--------|
+| 📘 Part I: IDaaS Foundations | 1–4 | IAM principles, AuthN vs AuthZ, identity lifecycle |
+| 📗 Part II: Protocols & Standards | 5–9 | OAuth 2.0/2.1, OpenID Connect, SAML 2.0, LDAP, SCIM |
+| 📙 Part III: Core Capabilities | 10–13 | SSO, MFA, identity federation, audit & compliance |
+| 📕 Part IV: Implementation | 14–19 | Keycloak, Apereo CAS, Dex, solution comparison, integration patterns, K8s deployment |
+| 📓 Part V: Advanced Topics | 20–24 | RBAC/ABAC/ReBAC, security, DID/VC, Zero Trust, performance |
+| 📎 Appendix | — | IDaaS terminology quick reference |
 
 <details>
-<summary>点击展开完整目录</summary>
+<summary>📖 Full Table of Contents</summary>
 
-**第一部分 · IDaaS 基础**
-- 第 1 章：什么是 IDaaS —— 定义、演进与核心价值
-- 第 2 章：IAM 核心理念 —— AAA 模型、设计原则与架构
-- 第 3 章：认证与授权深度辨析 —— AuthN vs AuthZ
-- 第 4 章：身份生命周期管理 —— 从创建到注销的全流程
+**Part I · IDaaS Foundations**
+- Chapter 1: What is IDaaS — definition, evolution, and core value
+- Chapter 2: IAM core concepts — AAA model, design principles, and architecture
+- Chapter 3: Authentication vs Authorization deep dive
+- Chapter 4: Identity lifecycle management
 
-**第二部分 · 协议与标准**
-- 第 5 章：OAuth 2.0 深度解读 —— 授权模式、Token 管理、OAuth 2.1
-- 第 6 章：OpenID Connect —— ID Token、UserInfo、发现机制
-- 第 7 章：SAML 2.0 —— 断言、绑定、元数据与联邦
-- 第 8 章：LDAP 与目录服务 —— Active Directory 集成
-- 第 9 章：SCIM 协议 —— 标准化用户配置
+**Part II · Protocols & Standards**
+- Chapter 5: OAuth 2.0 in depth — grant types, token management, OAuth 2.1
+- Chapter 6: OpenID Connect — ID Token, UserInfo, discovery
+- Chapter 7: SAML 2.0 — assertions, bindings, metadata, and federation
+- Chapter 8: LDAP & directory services — Active Directory integration
+- Chapter 9: SCIM protocol — standardized user provisioning
 
-**第三部分 · 核心能力**
-- 第 10 章：单点登录（SSO）—— 架构模式与会话管理
-- 第 11 章：多因素认证（MFA）—— TOTP、FIDO2、自适应认证
-- 第 12 章：身份联邦与代理 —— 跨域身份互信
-- 第 13 章：审计与合规 —— 等保、ISO 27001、异常检测
+**Part III · Core Capabilities**
+- Chapter 10: Single Sign-On (SSO) — architecture patterns and session management
+- Chapter 11: Multi-Factor Authentication (MFA) — TOTP, FIDO2, adaptive auth
+- Chapter 12: Identity federation & proxying — cross-domain trust
+- Chapter 13: Audit & compliance — ISO 27001, anomaly detection
 
-**第四部分 · 实现与实践**
-- 第 14 章：Keycloak 架构深度解析
-- 第 15 章：Apereo CAS —— 教育与企业 SSO
-- 第 16 章：Dex 身份代理 —— Kubernetes 原生方案
-- 第 17 章：IDaaS 方案全景对比 —— 选型决策框架
-- 第 18 章：集成模式与实践 —— 网关、BFF、Sidecar
-- 第 19 章：Kubernetes 生产环境部署
+**Part IV · Implementation & Practice**
+- Chapter 14: Keycloak architecture deep dive
+- Chapter 15: Apereo CAS — education & enterprise SSO
+- Chapter 16: Dex identity proxy — Kubernetes-native solution
+- Chapter 17: IDaaS landscape comparison — decision framework
+- Chapter 18: Integration patterns — gateway, BFF, Sidecar
+- Chapter 19: Kubernetes production deployment
 
-**第五部分 · 高级主题**
-- 第 20 章：授权模型深度对比 —— RBAC、ABAC、ReBAC
-- 第 21 章：IDaaS 安全最佳实践
-- 第 22 章：性能与扩展性
-- 第 23 章：去中心化身份与可验证凭证
-- 第 24 章：零信任与身份驱动安全
+**Part V · Advanced Topics**
+- Chapter 20: Authorization models — RBAC, ABAC, ReBAC
+- Chapter 21: IDaaS security best practices
+- Chapter 22: Performance & scalability
+- Chapter 23: Decentralized identity & verifiable credentials
+- Chapter 24: Zero Trust & identity-driven security
 
 </details>
 
-## 本书亮点
+## Who Should Read
 
-- 🧭 **体系完整**：从概念到协议、从能力到工程、从现状到趋势，一条主线贯穿。
-- 🔬 **协议深读**：OAuth 2.0 / OIDC / SAML / SCIM 不止讲用法，更讲安全边界与常见误区。
-- ⚙️ **工程落地**：Helm / Operator 部署、网关与 BFF 集成、高可用与监控，配套真实配置示例。
-- 🧩 **方案对比**：横向对比主流开源 IDaaS，附选型决策框架，避免「只有一个工具」的视角。
-- 🛡️ **前沿覆盖**：零信任、去中心化身份（DID / VC）、ReBAC 关系型授权等新趋势独立成章。
+Chinese-reading engineers, architects, and security professionals who need authoritative identity knowledge without language barriers:
 
-## 在线阅读
+- 🏗️ **Architects & Tech Leads** — planning SSO, identity platforms, permission governance
+- 🔐 **Security Teams** — MFA, audit compliance, Zero Trust, identity federation
+- 🧑‍💻 **Backend / Platform Engineers** — integrating OAuth, OIDC, SAML, LDAP, or Keycloak
+- 🧭 **SaaS / Platform Teams** — multi-tenant account design, RBAC, user lifecycle
+- 🆕 **IAM Beginners** — build a complete identity domain knowledge system
 
-🌐 托管站点（自动随主分支部署）：**[idaas.xlabs.club](https://idaas.xlabs.club)**
+## Reading Paths
 
-支持全文搜索、目录导航与暗色模式。
+| Your goal | Start here |
+|-----------|-----------|
+| Quick overview | [Introduction & Reading Guide](https://idaas.xlabs.club/docs/guides/introduction/) → Chapters 1–9 |
+| Building SSO / protocol integration | OAuth 2.0 → OpenID Connect → SAML → SSO → Integration Patterns |
+| Choosing an identity platform | Keycloak Architecture → CAS / Dex → Comparison → K8s Deployment |
+| Designing authorization | AuthN vs AuthZ → RBAC/ABAC/ReBAC → Audit & Compliance |
+| Hardening security | MFA → Best Practices → Zero Trust |
 
-## 本地开发
+## 🌐 Read Online
 
-本项目基于 [Hugo](https://gohugo.io/) + [Doks](https://github.com/thuliteio/doks) 主题构建。
+**[idaas.xlabs.club](https://idaas.xlabs.club)** — full-text search, dark mode, table of contents navigation. Auto-deployed from `main`.
+
+## 🚀 Local Development
+
+Built with [Hugo](https://gohugo.io/) + [Doks](https://github.com/thuliteio/doks) theme.
 
 ```bash
-# 安装依赖
-npm install
-
-# 启动本地开发服务器 http://localhost:1313/
-npm run dev
-
-# 编译生产版本到 public/
-npm run build
+npm install          # install dependencies
+npm run dev          # start dev server → http://localhost:1313
+npm run build        # production build → public/
 ```
 
-> 需要 Node.js 与 Hugo Extended。详见 [Hugo 官方文档](https://gohugo.io/installation/)。
+Requires Node.js 26 and Hugo Extended.
 
-## 贡献
+## 🤝 Contributing
 
-本书仍持续完善中，欢迎共同打磨：
+This book is continuously improving. All contributions welcome:
 
-- 发现错别字、技术谬误或失效链接 → 提交 [Issue](https://github.com/l10178/idaas-book/issues)
-- 补充案例、图示或章节 → 欢迎提交 [Pull Request](https://github.com/l10178/idaas-book/pulls)
-- 有想看的主题或建议 → 在 Issue 中标记 `discussion`
+- **Found an error?** → [Open an Issue](https://github.com/l10178/idaas-book/issues)
+- **Want to add content?** → [Submit a Pull Request](https://github.com/l10178/idaas-book/pulls)
+- **Have a topic request?** → Tag `discussion` in Issues
 
-请确保 PR 中的章节遵循现有 frontmatter 规范（`title` / `description` / `weight` / `menu` / `toc`），并保持章节编号与排版风格一致。
+PRs should follow existing frontmatter conventions (`title`, `description`, `weight`, `menu`, `toc`) and maintain consistent chapter numbering and style.
 
-## 致谢
+## 📊 Why Star This Repo
 
-感谢所有为身份与开源社区贡献协议、文档与代码的工程师们——本书站在它们的肩膀上。
+If you're working with identity — or know you will — starring this repo:
 
-如果这本书对你有帮助，欢迎 ⭐ Star 支持，让更多需要的人看到它。
+- 📌 Bookmarks a growing reference that stays current
+- 🔔 Notifies you of new chapters and protocol updates
+- 📈 Helps more Chinese-speaking engineers discover a systematic identity resource
 
-## License
+**No paywall, no registration, no vendor lock-in.** Just a book that wants to be useful.
 
-本书内容采用 [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)（署名-非商业性使用 4.0 国际）许可协议。转载请注明出处并保留原始链接，商业使用请先联系作者。
+## ⚖️ License
 
-项目源码（Hugo 站点脚手架与配置）沿用上游 [Doks](https://github.com/thuliteio/doks) 的相关许可。
+Content: [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) (Attribution-NonCommercial).  
+Site scaffolding: follows upstream [Doks](https://github.com/thuliteio/doks) license.
+
+---
+
+> 🧭 *"Trust is hard. Knowing who to trust is even harder."* — this book helps you navigate both.

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,72 +1,106 @@
 ---
-title: "IDaaS 身份即服务 —— 一本完整的书"
-description: "一本关于身份即服务的完整书籍"
-lead: "从 IAM 基础原理到 OAuth 2.0、OIDC、SAML 协议深度解读，从 Keycloak、CAS、Dex 开源方案到生产环境部署，一本关于 IDaaS（身份即服务）的完整技术书籍。"
+title: "IDaaS Book：企业身份与访问管理实战全书"
+description: "面向架构师、安全团队与平台工程师的中文 IDaaS / IAM 系统手册。覆盖 OAuth 2.0、OIDC、SAML、Keycloak 生产部署、零信任与身份治理。"
+lead: "从一次登录到零信任架构——系统掌握企业身份基础设施的设计、协议、工程落地与安全治理。全书 5 部分 24 章，约 13 万字，持续更新。"
 date: 2023-09-07T16:33:54+02:00
-lastmod: 2024-05-05T00:00:00+08:00
+lastmod: 2026-07-06T00:00:00+08:00
 draft: false
 seo:
-  title: "IDaaS Book —— 一本关于身份即服务的完整书籍"
-  description: "IDaaS 身份即服务完整书籍：涵盖 IAM 基础、OAuth 2.0、OIDC、SAML 2.0、LDAP、SCIM 协议、Keycloak/CAS/Dex 开源方案、SSO/MFA/身份联邦、授权模型、Kubernetes 生产部署、零信任与去中心化身份"
+  title: "IDaaS Book：企业身份与访问管理实战全书 | OAuth 2.0 · Keycloak · SSO · 零信任"
+  description: "面向架构师与平台工程师的中文 IDaaS / IAM 系统手册。覆盖 OAuth 2.0、OpenID Connect、SAML、Keycloak 生产部署、RBAC/ABAC、零信任与身份治理。在线阅读，持续更新。"
   canonical: ""
   noindex: false
 ---
 
-## 关于本书
+## 企业身份，不该每次都从头踩坑
 
-这是一本系统性的关于 **IDaaS（Identity as a Service，身份即服务）** 的技术书籍。
+几乎所有现代应用都绕不开身份认证与授权，但它从来不只是「接一个登录页」那么简单。
 
-本书从 IAM 的基础概念出发，深入到每一个核心协议（OAuth 2.0、OpenID Connect、SAML 2.0、LDAP、SCIM），讲解 IDaaS 平台的核心能力（SSO、MFA、身份联邦、审计合规），对比主流开源方案（Keycloak、CAS、Dex、Casdoor 等），并给出生产环境部署和集成的最佳实践。最后，我们还会探讨授权模型、零信任架构和去中心化身份等前沿话题。
+真正复杂的地方在于：**账号从哪里来、组织架构如何同步、权限边界如何治理、多个系统如何单点登录、审计合规如何落地，以及当业务规模增长后如何稳定运行。**
 
-**本书共 5 个部分、24 章，约 13 万字。** 适合 IDaaS 初学者、IAM 工程师、架构师以及任何对身份认证领域感兴趣的开发者阅读。
+**《IDaaS Book》是当前最完整的中文企业身份（IAM）实战全书。** 它把协议原理、架构设计、产品选型、工程落地和安全治理串成一条主线——让做登录、权限、身份中台和零信任接入的团队，有一份可以随时翻阅的系统参考。
 
-## 内容结构
+---
 
-### 第一部分：IDaaS 基础
-- 第1章：什么是 IDaaS —— 定义、演进与核心价值
-- 第2章：IAM 核心理念 —— AAA 模型、设计原则与架构
-- 第3章：认证与授权深度辨析 —— AuthN vs AuthZ
-- 第4章：身份生命周期管理 —— 从创建到注销的全流程
+## 这本书能帮你解决什么
 
-### 第二部分：协议与标准
-- 第5章：OAuth 2.0 深度解读 —— 授权模式、Token 管理
-- 第6章：OpenID Connect —— ID Token、UserInfo、发现机制
-- 第7章：SAML 2.0 —— 断言、绑定、元数据与联邦
-- 第8章：LDAP 与目录服务 —— Active Directory 集成
-- 第9章：SCIM 协议 —— 标准化用户配置
+| 你遇到的问题 | 书中对应章节 |
+|-------------|------------|
+| OAuth 2.0 授权码、隐式、客户端凭证……到底用哪个？ | [OAuth 2.0 深度解读]({{< relref "docs/protocols/oauth2-deep-dive.md" >}}) — 四种模式 + 安全边界 |
+| OIDC 和 OAuth 2.0 的区别是什么？ID Token 里有什么？ | [OpenID Connect]({{< relref "docs/protocols/openid-connect.md" >}}) — 认证层协议完整拆解 |
+| SAML 还在用吗？和 OIDC 怎么选？ | [SAML 2.0]({{< relref "docs/protocols/saml2.md" >}}) + [方案对比]({{< relref "docs/implementation/other-idaas-solutions.md" >}}) |
+| Keycloak 怎么在生产环境部署？Operator 还是 Helm？ | [Keycloak 架构]({{< relref "docs/keycloak/_index.md" >}}) + [K8s 生产部署]({{< relref "docs/implementation/kubernetes-production.md" >}}) |
+| RBAC 够用吗？什么时候需要 ABAC 或 ReBAC？ | [授权模型深度对比]({{< relref "docs/advanced-topics/authorization-models.md" >}}) |
+| 多租户 SaaS 怎么设计账号体系？ | [集成模式]({{< relref "docs/implementation/integration-patterns.md" >}}) + [身份生命周期]({{< relref "docs/fundamentals/identity-lifecycle.md" >}}) |
+| 零信任到底是什么？怎么落地？ | [零信任与身份驱动安全]({{< relref "docs/advanced-topics/zero-trust-identity.md" >}}) |
+| 等保 / ISO 27001 对身份系统有什么要求？ | [审计与合规]({{< relref "docs/core-capabilities/audit-and-compliance.md" >}}) |
 
-### 第三部分：核心能力
-- 第10章：单点登录（SSO）—— 架构模式与会话管理
-- 第11章：多因素认证（MFA）—— TOTP、FIDO2、自适应认证
-- 第12章：身份联邦与代理 —— 跨域身份互信
-- 第13章：审计与合规 —— 等保、ISO 27001、异常检测
+---
 
-### 第四部分：实现与实践
-- 第14章：Keycloak 架构深度解析
-- 第15章：Apereo CAS —— 教育与企业 SSO
-- 第16章：Dex 身份代理 —— Kubernetes 原生方案
-- 第17章：IDaaS 方案全景对比 —— 选型决策框架
-- 第18章：集成模式与实践 —— 网关、BFF、Sidecar
-- 第19章：Kubernetes 生产环境部署
+## 全书结构
 
-### 第五部分：高级主题
-- 第20章：授权模型深度对比 —— RBAC、ABAC、ReBAC
-- 第21章：IDaaS 安全最佳实践
-- 第22章：性能与扩展性
-- 第23章：去中心化身份与可验证凭证
-- 第24章：零信任与身份驱动安全
+全书共 **5 部分 · 24 章 · 约 13 万字**，附术语速查表。
 
-### 附录
-- 术语表 —— IDaaS 核心术语速查
+### 第一部分：IDaaS 基础（第 1–4 章）
+什么是 IDaaS、IAM 核心理念（AAA 模型）、认证与授权深度辨析、身份生命周期管理。
+
+### 第二部分：协议与标准（第 5–9 章）
+OAuth 2.0/2.1、OpenID Connect、SAML 2.0、LDAP 与目录服务、SCIM 协议。**不止讲字段，更讲安全边界、常见误区和生产踩坑。**
+
+### 第三部分：核心能力（第 10–13 章）
+单点登录（SSO）、多因素认证（MFA / FIDO2 / Passkey）、身份联邦与代理、审计与合规。
+
+### 第四部分：实现与实践（第 14–19 章）
+Keycloak 架构剖析、Apereo CAS、Dex 身份代理、方案全景对比与选型框架、集成模式（网关/BFF/Sidecar）、Kubernetes 生产环境部署。
+
+### 第五部分：高级主题（第 20–24 章）
+授权模型深度对比（RBAC / ABAC / ReBAC）、安全最佳实践、性能扩展、去中心化身份（DID / VC）、零信任架构。
+
+---
+
+## 推荐阅读路线
+
+| 目标 | 推荐路径 |
+|------|----------|
+| 🔰 快速建立体系 | [简介与阅读指南]({{< relref "docs/guides/introduction.md" >}}) → 第 1–4 章 → 第 5–9 章 |
+| 🔗 做 SSO / 协议接入 | OAuth 2.0 → OpenID Connect → SAML 2.0 → SSO → 集成模式 |
+| 🏗️ 做身份平台选型 | Keycloak 架构 → CAS / Dex → 方案对比 → Kubernetes 部署 |
+| 🛡️ 做权限治理 | AuthN vs AuthZ → RBAC/ABAC/ReBAC → 审计与合规 |
+| 🔐 做安全增强 | MFA → 安全最佳实践 → 零信任 |
+
+---
 
 ## 开始阅读
 
-点击左侧导航栏的"文档"，从第一部分开始系统阅读，或根据需求跳转到感兴趣的章节。
+- 📖 **系统阅读**：[完整文档目录]({{< relref "docs/_index.md" >}})
+- 🎯 **按角色选读**：[简介与阅读指南]({{< relref "docs/guides/introduction.md" >}})
+- ⚙️ **动手实践**：[Keycloak 实战指南]({{< relref "docs/keycloak/_index.md" >}})
 
-## 贡献
+---
 
-如果你发现了错误或有改进建议，欢迎到 [GitHub](https://github.com/l10178/idaas-book) 提交 Issue 或 Pull Request。
+## 这本书的特点
+
+- 🧭 **体系完整**：从概念到协议、从能力到工程、从现状到趋势，一条主线贯穿。
+- 🔬 **协议深读**：OAuth 2.0 / OIDC / SAML / SCIM 不止讲用法，更讲安全边界与常见误区。
+- ⚙️ **工程落地**：Helm / Operator 部署、网关与 BFF 集成、高可用与监控，配套真实配置示例。
+- 🧩 **方案对比**：横向对比主流开源 IDaaS，附选型决策框架。
+- 🛡️ **前沿覆盖**：零信任、DID / VC、ReBAC、Passkey / WebAuthn 独立成章。
+
+---
+
+## 贡献与反馈
+
+本书持续完善中。如果你发现技术错误、过时内容，或有真实落地案例想补充：
+
+- 🐛 提交 [Issue](https://github.com/l10178/idaas-book/issues)
+- ✨ 提交 [Pull Request](https://github.com/l10178/idaas-book/pulls)
+- 💬 有想看的主题？在 Issue 中标记 `discussion`
+
+如果这本书对你有帮助，欢迎 [⭐ Star](https://github.com/l10178/idaas-book) 支持，让更多需要的人看到它。
+
+---
 
 ## License
 
-本文档采用 [CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/) 许可协议。
+内容：[CC BY-NC 4.0](https://creativecommons.org/licenses/by-nc/4.0/)（署名-非商业性使用 4.0 国际）  
+站点脚手架：沿用上游 [Doks](https://github.com/thuliteio/doks) 许可


### PR DESCRIPTION
## Summary

Rewrote README as an English-first bilingual document and enhanced the homepage to improve star conversion, discoverability, and reader engagement.

## What changed

### README.md
- **Bilingual**: English positioning with Chinese content markers
- **Problem-solution framing**: table maps reader needs to content delivery
- **Visual structure**: badges, tables, collapsible TOC
- **Star CTA**: explains why starring benefits the reader
- **Reading paths**: role-based navigation table

### content/_index.md
- **Enhanced SEO metadata**: longer description, keyword-optimized title
- **Problem-solution table**: 8 common identity challenges mapped to specific chapters
- **Stronger lead**: frames the full identity journey
- **Book highlights section**: 5 key differentiators

### GitHub metadata
- Updated repo description (bilingual)
- Added 13 topics for discoverability

## Validation
- [x] Build passes: `npm run build` — 0 errors
- [x] No content changes — only README and homepage copy
- [x] All relref links validated by Hugo build
