### PR TITLE
docs: add IAM least privilege implementation guide and update solution blogs index

### DIFF
--- a/content/docs/solution-blogs/_index.md
+++ b/content/docs/solution-blogs/_index.md
@@ -33,3 +33,7 @@ menu:
 | [Keycloak 生产数据库配置 — PostgreSQL 实战]({{< relref "keycloak-postgresql-config" >}}) | H2 迁移 PostgreSQL、Kubernetes Secret 凭据管理、连接池调优、Liquibase 自动建表、常见数据库错误排错 |
 | [Keycloak 直连 K8s OIDC — API Server 认证与 RBAC]({{< relref "keycloak-kubernetes-rbac" >}}) | kube-apiserver OIDC 参数、groups claim 映射、kubelogin 接入、RBAC 绑定、与 Dex 方案对比 |
 | [Keycloak SMTP 邮件配置与密码重置]({{< relref "keycloak-smtp-email-config" >}}) | SMTP 配置（Gmail/企业微信/AWS SES）、忘记密码流程、邮箱验证、网络层排错、生产检查清单 |
+| [Keycloak 集群缓存调优与排错指南]({{< relref "keycloak-cluster-cache-tuning" >}}) | InfiniSpan 分布式缓存、JGroups 发现、缓存穿透、会话亲和性、集群脑裂诊断 |
+| [Supabase Auth 与 Keycloak 对比及集成]({{< relref "supabase-keycloak-integration" >}}) | Supabase GoTrue、Row Level Security、Keycloak 作为外部 OIDC 源、JWT 自定义 Claims、社交登录互通 |
+| [Dex 身份联邦指南：从原理到 K8s 集成]({{< relref "dex-identity-federation" >}}) | Dex OIDC Connector、Kubernetes OIDC 认证、多上游 IDP 联邦、groups claim 映射 |
+| [IAM 最小权限原则落地指南]({{< relref "iam-least-privilege-guide" >}}) | Least Privilege、权限反模式、JIT 提权、角色粒度分层、Keycloak 权限审计、等保最小权限要求 |

--- a/content/docs/solution-blogs/iam-least-privilege-guide.md
+++ b/content/docs/solution-blogs/iam-least-privilege-guide.md
@@ -1,0 +1,202 @@
+---
+title: "IAM 最小权限原则落地指南 — 从理论到 Keycloak 实战 | IDaaS Book"
+description: "IAM 最小权限原则（Least Privilege）完整落地指南：权限反模式、JIT 访问、时间绑定、Keycloak 细粒度授权与权限审计 Checklist"
+date: 2026-07-11T00:00:00+08:00
+draft: false
+weight: 68
+menu:
+  docs:
+    parent: "solution-blogs"
+    identifier: "iam-least-privilege-guide"
+toc: true
+---
+
+## 场景
+
+权限越给越多、无人回收、默认角色里夹带了不该有的权限——这是 IAM 系统最常见的退化路径。本指南聚焦**如何在日常运维中落地最小权限原则**，不重复概念定义，只讲可操作的步骤和反模式。
+
+**适用**：正在设计或治理企业 IAM 权限体系、需要等保合规（三级要求强制最小权限）、Keycloak 权限爆炸的管理员和架构师。
+
+**不适用**：概念阶段还没开始配权限的团队（先读 [IAM RBAC/ABAC/ReBAC 授权模型]({{< relref "../advanced-topics/authorization-models" >}})）。
+
+## 常见反模式
+
+在讨论怎么做之前，先识别当前权限设计中的「最小权限杀手」：
+
+| 反模式 | 表现 | 后果 |
+|--------|------|------|
+| **admin 扩散** | 每个新应用都创建 admin 角色，开发时为了方便先给所有人 admin | 审计时发现 30% 用户有管理员权限 |
+| **角色继承失控** | 为了省事让「员工」继承「经理」的角色权限，再让「实习生」也继承 | 实习生能审批报销单 |
+| **权限永不过期** | 临时项目组的权限在项目结束后无人回收 | 离职人员通过项目组权限仍然能访问资产 |
+| **默认允许** | Keycloak Authorization Services 没配 Policy，默认返回 Permit | 所有认证用户都能访问所有资源 |
+| **粗粒度角色** | 一个 `power-user` 角色包含 200 个权限，无法拆分 | 权限审计无法回答「谁能删除生产数据」 |
+| **权限复制粘贴** | 给新同事「跟老王一样的权限就行」 | 老王五年前的临时权限也被继承了 |
+
+识别出反模式后，下面的模式帮你逐一收敛。
+
+## 落地模式
+
+### 模式一：角色粒度分层
+
+不创建「全能角色」，而是按业务职能拆分为**原子角色**，用 Composite Roles 组合：
+
+```
+[订单查看]  [订单编辑]  [订单删除]  [报表导出]  [用户管理]
+     │           │           │           │           │
+     └───────────┴─────┬─────┴───────────┘           │
+                       │                             │
+                  [订单管理员]                   [系统管理员]
+              (Composite Role)               (Composite Role)
+```
+
+**Keycloak 操作**：在 Realm Roles 中创建原子角色，再用 Composite Roles 把原子角色组合成业务角色。用户→Group→Composite Role，不直接给用户赋原子角色。
+
+**为什么这么做**：一年后需要「只能查看不能删除」的新角色时，从原子角色池里重新组合，而不是新建一个 `订单查看员` 角色然后又忘了删旧的。
+
+### 模式二：Just-in-Time (JIT) 权限提升
+
+运维人员日常只用普通账号，需要操作生产环境时临时提权，操作完成后自动降级。
+
+```
+正常状态： user → viewer (只读)
+提权申请： user → operator (5 分钟，需审批)
+自动降级： 5 分钟后 operator → viewer
+```
+
+**Keycloak 实现方式**：
+
+1. 创建 `operator` 角色（Realm Role），不要直接分配给用户
+2. 创建一个临时 Group（如 `temp-operator-20260711`），将 `operator` 角色赋予该 Group
+3. 审批通过后，将用户加入该 Group，同时设置一个定时任务（如 Keycloak Admin REST API 调用 + CronJob）在到期后移除
+4. 所有角色变更事件通过 Admin Events 审计
+
+> Keycloak 原生不支持 Time-based Role，需要外部编排。对于简单场景，可以用一个脚本：`kcadm.sh add-roles --uusername alice --rolename operator` → sleep 300 → `kcadm.sh remove-roles --uusername alice --rolename operator`，配合审批工单系统触发。
+
+### 模式三：默认拒绝 + 显式允许
+
+Keycloak Authorization Services 的决策策略默认是「UNANIMOUS」（所有策略都通过才允许），但很多团队在配置时因为不熟悉而切换为「AFFIRMATIVE」甚至留空默认的 Permit 策略。
+
+**底线配置检查**：
+
+```bash
+# 检查某 Client 的 Authorization Settings
+# 确保 Default Policy 不是 Permit All
+kcadm.sh get clients/CLIENT_ID/authz/resource-server/settings -r REALM
+
+# 确认 decisionStrategy = "UNANIMOUS"
+# 确认 defaultResourceType 的 scope 策略没有通配符
+```
+
+**每个 Client 的 Authorization 上线前 checklist**：
+- [ ] 至少有一个 Deny Policy 作为兜底
+- [ ] 新 Resource 的默认策略不是 Permit
+- [ ] Policy Evaluation 验证过：无权限用户返回 Deny
+- [ ] 管理员角色不受 Authorization Services 限制（避免把自己锁在外面）
+
+### 模式四：定期权限审计
+
+IAM 权限不是「配置一次就完了」的东西。以下审计节奏是生产环境的底线：
+
+| 频率 | 检查项 | 工具/方式 |
+|------|--------|----------|
+| 每周 | 是否有超过 7 天未使用的 admin 角色分配 | Keycloak Admin REST API → `GET /admin/realms/{realm}/roles/{role}/users` + 最后登录时间对比 |
+| 每月 | 角色-权限矩阵与实际授权是否一致 | 导出 Realm JSON，用脚本对比预期 vs 实际 |
+| 每季度 | 完整权限回收：离职员工账号禁用、临时项目组清理、过期角色归档 | 结合 HR 系统离职名单交叉比对 |
+| 每半年 | 渗透测试：用一个 viewer 账号尝试访问 admin 接口 | 安全团队专项测试 |
+
+**Keycloak 权限审计脚本示例**（获取某角色的所有用户）：
+
+```bash
+# 获取 admin 角色的所有直接用户
+kcadm.sh get-roles -r REALM --uusername admin --effective --role-role admin_user
+
+# 导出所有用户的角色分配
+kcadm.sh get users -r REALM --max 500 | jq '.[] | {username: .username, roles: .realmRoles}'
+```
+
+## 与等保 2.0 的对应关系
+
+等保三级明确要求「最小权限」和「强制访问控制」。对照本指南：
+
+| 等保要求 | 对应模式 | 证据 |
+|---------|---------|------|
+| 账户-权限绑定 | 模式一 角色粒度分层 | 角色-权限矩阵表 |
+| 最小权限 | 模式三 默认拒绝 | Policy Evaluation 记录 |
+| 授权粒度到用户级 | 模式一 + 模式二 | 逐用户角色分配记录 |
+| 定期审计 | 模式四 权限审计 | 季度审计报告 |
+
+详细等保落地 Checklist 参见 [IAM 安全合规与等保 2.0]({{< relref "../advanced-topics/iam-compliance-dengbao" >}})。
+
+## 验证
+
+完成以上配置后，用以下测试用例验证最小权限是否生效：
+
+```bash
+# 1. 用 viewer 账号获取 token
+TOKEN=$(curl -s -X POST "https://keycloak.example.com/realms/REALM/protocol/openid-connect/token" \
+  -d "client_id=CLIENT_ID" -d "username=viewer" -d "password=PASS" \
+  -d "grant_type=password" | jq -r '.access_token')
+
+# 2. 尝试访问 admin 接口 → 期望返回 403
+curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN" \
+  "https://api.example.com/admin/users"
+
+# 3. 检查 Token 中的角色是否不包含 admin
+echo "$TOKEN" | cut -d'.' -f2 | base64 -d 2>/dev/null | jq '.resource_access'
+```
+
+## 常见错误
+
+| 症状 | 原因 | 解决 |
+|------|------|------|
+| 所有认证用户都能调 admin API | Authorization Services 的默认策略是 Permit 或未启用 | 启用 Authorization，将默认策略改为 Deny |
+| 给用户去掉了 admin 角色但仍然能访问 | 用户通过 Group 间接持有 admin 角色（Effective Roles 包含 Group 传递的角色） | 用 `--effective` 参数检查实际生效的角色 |
+| Policy Evaluation 显示 Permit 但实际 Deny | Authorization Scopes 配置了但 Resource 没有关联 Scope | 检查 Resource → Scopes 关联 |
+| 复合角色中的子角色权限丢失 | Composite Roles 中的子角色被误删或改名 | 用 Realm JSON 导出做 diff |
+| JIT 提权到期后权限未回收 | 定时任务失败或 Keycloak API 调用超时 | JIT 权限必须配合监控告警——提权超过 N 分钟未回收时触发 PagerDuty |
+
+## 回滚
+
+如果最小权限策略配得太严导致业务中断：
+
+1. **紧急回滚**：通过 Keycloak Admin Console → Users → 对受影响用户临时赋 `admin` 角色，恢复访问
+2. **分层回滚**：不要删掉整个 Authorization Services 配置——在 Policy 层面将目标 Policy 的 Logic 从 Positive 改为 Negative，或增加一个临时的宽松 Policy
+3. **事后修复**：用 Admin Events 日志追溯是谁在什么时间改了哪个 Policy，复盘「为什么测试时没发现」
+
+## IAM 最小权限 FAQ
+
+### Q1：IAM 里最小权限和 RBAC 有冲突吗？
+
+不冲突，但 RBAC 的默认行为倾向于「角色越多权限越大」。最小权限要求在 RBAC 基础上加三层约束：(1) 角色粒度足够细（原子角色）；(2) 默认拒绝而非默认允许；(3) 权限分配有时间边界（JIT 或定期回收）。
+
+### Q2：公司刚起步，IAM 权限从什么粒度开始？
+
+三个阶段：
+
+1. **10 人以下**：admin / user 两个角色就够了。但必须约定「admin 是紧急权限，日常用 user」。
+2. **10-50 人**：引入职能角色（开发、运维、财务、人事），每个角色 3-5 个权限。开始用 Keycloak Groups 做组织映射。
+3. **50 人以上**：参考本指南的模式一「角色粒度分层」，开始做季度权限审计。
+
+关键不是一开始就完美，而是**让权限变更可追溯**——哪怕只有两个角色，每次角色分配都有一条审计记录。
+
+### Q3：IAM 最小权限和零信任是什么关系？
+
+零信任架构的三条核心原则之一是「最低权限访问」。在零信任体系中，IAM 的职责不仅是给你一个角色——而是每次访问都根据用户身份、设备状态、网络位置、行为风险做实时决策。本指南的模式二（JIT 提权）和模式三（默认拒绝）就是零信任理念在 IAM 权限管理中的落地形式。更多架构细节见 [零信任 IAM 架构]({{< relref "../advanced-topics/zero-trust-identity" >}})。
+
+### Q4：已经权限爆炸了，IAM 怎么往回改？
+
+三步走：
+
+1. **盘点**：导出所有用户-角色-权限映射（参考模式四的脚本），找出「一人多角色」和「从未使用的角色」。
+2. **冻结**：暂停新增角色。所有新权限需求通过已有的原子角色组合满足，不再创建新角色。
+3. **收敛**：每两周清理一批 3 个月未使用的角色。清理前提前一周通知受影响用户。
+
+这个过程通常需要 2-3 个月。关键是第一步的盘点——不知道有多少问题就没法解决问题。
+
+## 相关阅读
+
+- [IAM RBAC / ABAC / ReBAC 授权模型对比与选型]({{< relref "../advanced-topics/authorization-models" >}})：三种授权模型的完整对比
+- [Keycloak 细粒度权限与授权策略实战]({{< relref "keycloak-fine-grained-authz" >}})：Authorization Services 的配置实操
+- [IAM 安全合规与等保 2.0 要求]({{< relref "../advanced-topics/iam-compliance-dengbao" >}})：最小权限的合规视角
+- [IAM 安全最佳实践]({{< relref "../advanced-topics/security-best-practices" >}})：包括 Token 保护、密钥管理、攻击面防御


### PR DESCRIPTION
## Summary

新增 IAM 最小权限原则落地指南，同时更新 solution blogs 索引补全缺失条目。

## Changed files

- **新增** `content/docs/solution-blogs/iam-least-privilege-guide.md` — IAM 最小权限落地指南
  - 六种常见权限反模式
  - 四种落地模式：角色粒度分层、JIT 提权、默认拒绝、定期审计
  - Keycloak 具体实现命令与 Checklist
  - 等保 2.0 对照表
  - 4 条 IAM FAQ
- **修改** `content/docs/solution-blogs/_index.md` — 补全 4 个遗漏条目（cluster-cache-tuning、supabase-keycloak、dex-identity-federation、iam-least-privilege-guide）

## Technical sources

- NIST SP 800-63B (密码策略)
- GB/T 22239-2019 等保 2.0 安全计算环境要求
- Keycloak Authorization Services 官方文档
- IAM RBAC/ABAC/ReBAC 已有章节交叉引用

## SEO/GEO impact

- **IAM 关键词覆盖**：「IAM 最小权限」「Least Privilege」「IAM 权限审计」「JIT 提权」「IAM 权限反模式」
- **结构化内容**：FAQ 区块（4 条）、对比表、Checklist——适配 AI 搜索引擎引用
- **长尾词命中**：「IAM 最小权限 落地」「等保 IAM 最小权限」「IAM 权限爆炸 怎么办」
- **内链**：关联 authorization-models、keycloak-fine-grained-authz、iam-compliance-dengbao、security-best-practices、zero-trust-identity
- **索引维护**：solution blogs 索引现涵盖 20 个条目，搜索引擎可完整索引所有方案页

## Validation

- `npm run build` — 通过，157 pages，无新增 warning

## Risk/rollback

- 低风险：仅新增页面和索引表行，无现有内容修改
- 如需回滚：revert 此 PR 即可，不影响其他页面