### PR TITLE
docs: make oauth2-proxy image version explicit

### DIFF
--- a/content/docs/solution-blogs/keycloak-oauth2-proxy.md
+++ b/content/docs/solution-blogs/keycloak-oauth2-proxy.md
@@ -172,7 +172,8 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: quay.io/oauth2-proxy/oauth2-proxy:v7.8.2
+        # 生产环境请固定到已验证的版本，不要直接使用 latest。
+        image: quay.io/oauth2-proxy/oauth2-proxy:<已验证版本>
         args:
         - --provider=keycloak-oidc
         - --oidc-issuer-url=https://keycloak.example.com/realms/myrealm


### PR DESCRIPTION
## Summary
- 将 Keycloak + oauth2-proxy 的 Kubernetes 示例从固定但未经当前验证的镜像版本改为显式占位符。
- 在配置旁提醒生产环境必须选择并固定经过验证的版本，避免复制示例时意外漂移到不可控镜像。

## Changed files
- `content/docs/solution-blogs/keycloak-oauth2-proxy.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/

## SEO/GEO impact
- 保留并强化“Keycloak oauth2-proxy 配置”“Keycloak Kubernetes 生产部署”场景的可复制性与版本治理提示，降低读者照搬过时镜像标签的风险。

## Validation
- `npm run build` passed: Hugo 0.164.0, 173 pages.
- `git diff --check` passed.
- Existing warning: Hugo `css.Sass`/libsass deprecation; unrelated to this documentation-only change.

## Risk/rollback
- 仅修改文档示例，不改变运行时代码或依赖。
- 若需回滚，revert 本次 squash merge；恢复此前的示例标签。