### PR TITLE
docs: tighten oauth2-proxy header defaults

### DIFF
--- a/content/docs/solution-blogs/keycloak-oauth2-proxy.md
+++ b/content/docs/solution-blogs/keycloak-oauth2-proxy.md
@@ -192,6 +192,8 @@ spec:
         - --reverse-proxy=true
         # 只信任 Ingress/反向代理的出口网段；按实际集群网段替换。
         - --trusted-proxy-ip=10.42.0.0/16
+        # auth-url 模式通常不需要把 Basic Auth 头交给业务应用。
+        - --pass-basic-auth=false
         - --set-xauthrequest=true
         - --email-domain=*
         - --scope=openid email profile
@@ -248,6 +250,7 @@ spec:
 | `--upstream=static://202` | 固定 202 响应 | auth-url 模式：oauth2-proxy 仅做认证判定，不代理到后端 |
 | `--reverse-proxy` | `true` | 信任反向代理传入的 `X-Forwarded-*` 头 |
 | `--trusted-proxy-ip` | Ingress 出口 IP/CIDR | 限制哪些来源可以提供 `X-Forwarded-*`。不要在生产环境省略，否则能直连 oauth2-proxy 的请求方可能伪造 Host、Proto 或原始 URI |
+| `--pass-basic-auth` | `false` | auth-url 模式不需要 Basic Auth 头；显式关闭，避免把无用的认证信息传给后端 |
 | `--set-xauthrequest` | `true` | 向后端传递 `X-Auth-Request-User`、`X-Auth-Request-Email`、`X-Auth-Request-Groups` 等头 |
 | `--pass-access-token` | 默认不启用 | 将 OAuth Access Token 传给上游；只有后端确实要消费 Access Token 时才启用，并配合 Ingress 显式复制响应头 |
 | `--email-domain` | `*` | 允许所有邮箱域。如需限定，改为 `example.com` 或 `--authenticated-emails-file` |

--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -291,7 +291,7 @@ oauth2-proxy[1] <timestamp> <request> 403 missing state parameter
 cookie value too long (4096 bytes max)
 ```
 
-**根因**：oauth2-proxy 把 ID Token、Access Token、Refresh Token 全部加密存在 Cookie 里。如果 Token 中包含大量 claims（如组列表、角色列表），Cookie 可能超过浏览器 4096 字节限制。
+**根因**：Cookie Store 会把会话数据放入加密 Cookie；如果 Token 中包含大量 claims（如组列表、角色列表），Cookie 可能超过浏览器或代理的单 Cookie 大小限制。具体内容取决于 Provider、Session Store 和配置，不应假定三种 Token 都一定完整地存进 Cookie。
 
 高发于：Keycloak 用户属于几十个 group，每个 group 名字又很长。
 
@@ -308,12 +308,14 @@ args:
 # 生产环境还应通过 Secret 注入 Redis 凭据，并校验证书；不要把密码写进 Git
 ```
 
-**方案 2：精简 Cookie 内容**
+**方案 2：关闭不需要的凭据转发**
 
 ```yaml
 # 如果后端不需要 Access Token，不传递
 # --pass-access-token=false
 # --set-authorization-header=false
+# auth-url 模式也不需要 Basic Auth 头
+- --pass-basic-auth=false
 ```
 
 **方案 3：减少 Token 中的 claims**


### PR DESCRIPTION
## Summary
- 在 Keycloak + oauth2-proxy 的 auth-url 最小配置中显式关闭 `--pass-basic-auth`。
- 修正 Cookie Store 对会话内容的描述，避免把 Token 存储实现写成固定行为。
- 在 Cookie 过大排错中补充关闭不需要的 Basic Auth 凭据转发。

## Changed files
- `content/docs/solution-blogs/keycloak-oauth2-proxy.md`
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`

## Technical sources
- oauth2-proxy configuration overview: https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- ingress-nginx external authentication example: https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/
- oauth2-proxy issue #2165（开放重定向的安全讨论，作为 redirect 边界背景）：https://github.com/oauth2-proxy/oauth2-proxy/issues/2165

## SEO/GEO impact
补强“IAM 网关 + oauth2-proxy 配置/排错”页面中可直接引用的安全边界和配置决策，覆盖 `oauth2-proxy` Header 暴露与 Cookie 过大排错意图；不新增页面、不堆叠关键词。

## Validation
- `npm install`
- `npm run build` ✅ Hugo 构建成功（188 pages）；保留既有 Sass deprecated 与 taxonomy description warnings。
- `git diff --check` ✅

## Risk/rollback
- 风险低：仅文档配置示例和行为描述，未修改站点模板或依赖。
- 若现有应用确实依赖 Basic Auth 头，移除示例参数后需在业务配置中显式启用 `--pass-basic-auth=true`；回滚本 PR 即可恢复原文。