### PR TITLE
docs: tighten oauth2-proxy troubleshooting boundaries

### DIFF
--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -2,7 +2,7 @@
 title: "IAM 网关 oauth2-proxy 常见错误排错 | IDaaS Book"
 description: "IAM 网关 oauth2-proxy 集成 Keycloak 的 12 个高频错误排错：CSRF Cookie、expected audience、redirect loop、invalid_token 与 Nginx 401。"
 date: 2026-07-13T00:00:00+08:00
-lastmod: 2026-07-13T00:00:00+08:00
+lastmod: 2026-07-27T23:00:00+08:00
 draft: false
 weight: 3
 menu:
@@ -16,7 +16,7 @@ toc: true
 
 你按照文档配好了 oauth2-proxy + Keycloak，部署到 Kubernetes，打开浏览器——白屏、401、无限跳转、或者 "csrf cookie not found"。这些错误 oauth2-proxy 的日志里写得很直白，但**为什么发生、怎么修**才是真正的卡点。
 
-这篇文章把 GitHub Issues 和 Stack Overflow 上反复出现的高频错误整理成速查表：每条有诊断命令、根因分析、修复步骤。不需要逐条 Google——直接对号入座。
+这篇文章把 oauth2-proxy 的公开 Issue 与可复现的配置逻辑整理成速查表：每条有诊断命令、根因分析和修复步骤。Issue 只能说明问题曾被报告，不能替代当前版本的验证。
 
 适用：oauth2-proxy v7.x + Keycloak（任意版本），auth-url 或 ForwardAuth 模式。
 
@@ -49,7 +49,7 @@ toc: true
 oauth2-proxy[1] <timestamp> <request> 403 csrf cookie not found
 ```
 
-**根因**：oauth2-proxy 在发起 OAuth 授权请求前，会生成一个 `_oauth2_proxy_csrf` Cookie（存储 state 参数的非对称哈希）。OAuth Provider（Keycloak）回调时，浏览器必须把这个 Cookie 原样带回 `/oauth2/callback`。以下任何一环断了都会触发这个错误：
+**根因**：oauth2-proxy 在发起 OAuth 授权请求前，会生成一个 `_oauth2_proxy_csrf` Cookie，用于把回调与此前的授权请求关联起来。OAuth Provider（Keycloak）回调时，浏览器必须把这个 Cookie 带回 `/oauth2/callback`。以下任何一环断了都会触发这个错误：
 
 1. **Cookie 被浏览器拒绝**：SameSite 过严 / Secure 标记与 HTTP 不匹配 / Domain 不匹配
 2. **Cookie 路径不匹配**：CSRF Cookie 默认 path 为 `/`，但如果被反向代理改写可能出现不一致
@@ -142,7 +142,7 @@ oauth2-proxy[1] <timestamp> <request> 401 error validating token:
 oidc: expected audience "oauth2-proxy" got ["account"]
 ```
 
-**根因**：oauth2-proxy v7.4+ 默认启用 `--insecure-oidc-skip-issuer-verification=false`，会校验 ID Token 的 `aud`（audience）字段。Keycloak 默认只在 `aud` 里填 `account`（代表 Account Console），不包含 Client ID。
+**根因**：oauth2-proxy 的 OIDC 校验会检查 ID Token 的 `aud`（audience）是否包含配置的 Client ID；`--insecure-oidc-skip-issuer-verification` 控制的是 `iss` 校验，不是 audience 校验。Keycloak 是否把 `oauth2-proxy` 写入 `aud` 取决于实际启用的 Client Scope/Protocol Mapper，不能仅凭版本或默认 Token 形状推断。
 
 ### 诊断
 
@@ -386,7 +386,7 @@ metadata:
 could not get claim: missing claim "email"
 ```
 
-**根因**：oauth2-proxy 默认要求 ID Token 中必须有 `email` claim。某些用户（如 LDAP 联邦过来的用户、Keycloak 内部 service account）在 Keycloak 中没有配置邮箱。
+**根因**：当前配置或 Provider 校验路径需要 `email` claim，但该用户的 ID Token 没有它。LDAP/AD 属性映射、用户资料是否填写，以及请求的 scope/client scope 都可能影响最终 Token；不要仅凭管理界面能看到邮箱就推断它一定进入了 ID Token。
 
 ### 修复
 
@@ -394,22 +394,13 @@ could not get claim: missing claim "email"
 
 在 Keycloak 中：Users → 目标用户 → Attributes → 添加 `email` 属性；或用 User Federation mapper 从 LDAP/AD 映射 `mail` → `email`。
 
-**方案 2：放宽 oauth2-proxy 的 email 要求**
+**方案 2：不要用伪造邮箱绕过身份校验**
 
-```yaml
-args:
-- --insecure-oidc-allow-unverified-email=true
-- --email-domain=*   # 允许所有域（包括空邮箱）
-```
+不要把 `--insecure-oidc-allow-unverified-email=true`、`--email-domain=*` 或硬编码的 `@placeholder.local` 地址当作生产修复：它们可能扩大可登录范围，且不能补出缺失的用户身份属性。
 
-**方案 3（推荐）：创建 Keycloak Protocol Mapper 保底**
+**方案 3（推荐）：修正真实身份属性的来源**
 
-在 Client Scope 中添加一个 **Hardcoded claim** mapper：如果用户没有邮箱，回退到 username + `@placeholder.local`：
-
-1. Clients → oauth2-proxy → Client scopes → 专用 scope
-2. Add mapper → **Hardcoded claim**
-3. Token Claim Name: `email`, Claim value: 留空
-4. 再添加一个 **User Attribute** mapper（email → email），优先级更高
+确认 LDAP/AD 的 `mail` 属性已映射到 Keycloak 的 `email`，用户资料中的邮箱已填写并按组织规则验证；确认客户端请求了需要的 scope，并用新签发的 ID Token 检查 claim。若业务确实不把邮箱作为身份标识，应按当前 oauth2-proxy 版本的 Provider 配置选择稳定的用户标识，而不是伪造邮箱；改动前先在测试 Realm 验证登录、域名限制和审计字段。
 
 ---
 


### PR DESCRIPTION
## Summary
- Clarify that `insecure-oidc-skip-issuer-verification` is about `iss`, not `aud`.
- Remove the unsafe recommendation to fabricate placeholder email claims.
- Make the missing-email diagnosis depend on actual claims, scopes, and federation mappings.
- Correct the CSRF explanation so it does not overstate the Cookie Store behavior.

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://github.com/oauth2-proxy/oauth2-proxy/issues/3258
- https://datatracker.ietf.org/doc/html/rfc6749#section-10.12
- https://www.keycloak.org/documentation

## SEO/GEO impact
Improves the IAM/oauth2-proxy troubleshooting page for searches around `csrf cookie not found`, `expected audience`, `missing email claim`, and unsafe OIDC verification workarounds. The existing IAM title, description, FAQ, and internal links are preserved.

## Validation
- `npm ci`
- `npm run build` passed with existing Hugo warnings only (deprecated `css.Sass` and short descriptions on taxonomy pages).
- `git diff --check` passed.

## Risk/rollback
Documentation-only change. Roll back by reverting this commit or restoring the previous version of the page; no runtime configuration or dependency was changed.