### PR TITLE
docs: fix SCIM endpoint example

### DIFF
--- a/content/docs/solution-blogs/iam-scim-provisioning-guide.md
+++ b/content/docs/solution-blogs/iam-scim-provisioning-guide.md
@@ -23,7 +23,7 @@ toc: true
 - 需要满足合规要求（如等保 2.0 的"身份信息应定期审查"、"离职用户应在 24 小时内回收权限"）
 
 **不适用场景：**
-- 用户数量极少（< 50），手动管理成本可接受
+- 用户数量少、变更频率低，手动管理成本仍然可接受
 - 下游应用不支持 SCIM 且无法通过中间层适配
 - 身份源（HR 系统）本身不稳定，无法保证数据质量
 
@@ -121,10 +121,10 @@ HR 系统中的字段需要映射到 SCIM User Schema。以下是一个常见映
 **创建用户的 SCIM 请求示例：**
 
 ```bash
-curl -X POST \
-  https://keycloak.example.com/auth/realms/{realm}/scim/v2/Users \
-  -H "Authorization: Bearer $(< admin_token)" \
-  -H "Content-Type: application/scim+json" \
+curl -X POST \\
+  "${SCIM_BASE_URL}/Users" \\
+  -H "Authorization: Bearer ${SCIM_TOKEN}" \\
+  -H "Content-Type: application/scim+json" \\
   -d '{
     "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
     "externalId": "EMP-20260701",


### PR DESCRIPTION
## Summary
- remove an unsupported user-count cutoff from the IAM SCIM guide
- replace a misleading hard-coded Keycloak `/auth/realms/...` SCIM URL with the deployed SCIM server base URL
- use a placeholder Bearer token variable in the request example

## Changed files
- `content/docs/solution-blogs/iam-scim-provisioning-guide.md`

## Technical sources
- RFC 7644 (SCIM Protocol): https://www.rfc-editor.org/rfc/rfc7644
- Keycloak feature configuration: https://www.keycloak.org/server/features
- Keycloak server administration guide: https://www.keycloak.org/docs/latest/server_admin/

## SEO/GEO impact
Improves the IAM SCIM provisioning page for the real integration intent by making the copy-paste request portable across SCIM implementations and removing an unsupported numeric threshold. The existing IAM title, description, FAQ, and internal links remain unchanged.

## Validation
- `npm ci` passed
- `npm run build` passed with existing Hugo warnings (deprecated `css.Sass` and short taxonomy descriptions)
- `git diff --check` passed
- Markdown checks: frontmatter, four internal `relref` links, and IAM FAQ present

## Risk/rollback
Low-risk documentation-only change. Revert the merge commit or restore the previous example if a site-specific SCIM extension requires a different base path.