### PR TITLE
docs: clarify oauth2-proxy audience diagnosis

### DIFF
--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -142,7 +142,7 @@ oauth2-proxy[1] <timestamp> <request> 401 error validating token:
 oidc: expected audience "oauth2-proxy" got ["account"]
 ```
 
-**根因**：oauth2-proxy 的 OIDC 校验会检查 ID Token 的 `aud`（audience）是否包含配置的 Client ID；`--insecure-oidc-skip-issuer-verification` 控制的是 `iss` 校验，不是 audience 校验。Keycloak 是否把 `oauth2-proxy` 写入 `aud` 取决于实际启用的 Client Scope/Protocol Mapper，不能仅凭版本或默认 Token 形状推断。
+**根因**：oauth2-proxy 的 OIDC 校验会按 `aud`（audience）检查 ID Token 的接收方；当前配置文档中，`--oidc-audience-claim` 默认读取 `aud`，而 `--oidc-extra-audience` 只是额外允许的 audience。Keycloak 只把 `account` 放进 `aud` 时，Token 没有包含 oauth2-proxy 的 Client ID，因此会被拒绝。不要把这个错误归因于某个固定版本号：应以实际运行镜像的启动参数和配置文档为准。
 
 ### 诊断
 


### PR DESCRIPTION
## Summary
- 修正 oauth2-proxy `expected audience` 排错说明，改为以实际 OIDC 配置和当前官方参数语义为依据。
- 明确 `--oidc-audience-claim` 默认读取 `aud`、`--oidc-extra-audience` 的边界，并避免把行为绑定到未经验证的固定版本号。

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc
- https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/

## SEO/GEO impact
- 强化 IAM 网关、oauth2-proxy、Keycloak、expected audience 排错意图的可引用答案块。
- 保持现有 IAM FAQ、内部链接和页面结构，不新增重复页面。

## Validation
- `npm ci`
- `npm run build`（通过；Hugo 仅报告既有 Sass deprecated 与标签/分类 description warning）
- `git diff --check`（通过）
- Markdown frontmatter、IAM FAQ、内部 relref 检查通过

## Risk/rollback
- 风险低：仅修改一段诊断文字，无运行时代码或依赖变更。
- 回滚：revert 此 PR 的 squash commit。
