### PR TITLE
docs: clarify oauth2-proxy CSRF cookie settings

### DIFF
--- a/content/docs/solution-blogs/keycloak-oauth2-proxy.md
+++ b/content/docs/solution-blogs/keycloak-oauth2-proxy.md
@@ -184,6 +184,8 @@ spec:
         - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
         - --cookie-secure=true
         - --cookie-samesite=lax
+        # CSRF Cookie 默认继承 session Cookie 的 SameSite；显式写出，避免后续拆分配置时漂移。
+        - --cookie-csrf-samesite=lax
         - --cookie-domain=.example.com
         - --cookie-refresh=1h
         - --cookie-expire=24h
@@ -247,6 +249,7 @@ spec:
 | `--cookie-domain` | `.example.com` | 设置 Domain 属性，让主域名及其子域名匹配。是否带前导点不应作为隔离手段；不设置该参数才是 host-only Cookie |
 | `--cookie-secure` | `true` | 生产环境必须开启，只通过 HTTPS 传输 Cookie |
 | `--cookie-samesite` | `lax` | 允许从外部链接跳转时携带 Cookie（`strict` 会拦截来自 Keycloak 的回调） |
+| `--cookie-csrf-samesite` | `lax` | 单独控制 CSRF Cookie 的 SameSite 属性；默认值为空时继承 `--cookie-samesite`，显式设置便于审计 |
 | `--upstream=static://202` | 固定 202 响应 | auth-url 模式：oauth2-proxy 仅做认证判定，不代理到后端 |
 | `--reverse-proxy` | `true` | 信任反向代理传入的 `X-Forwarded-*` 头 |
 | `--trusted-proxy-ip` | Ingress 出口 IP/CIDR | 限制哪些来源可以提供 `X-Forwarded-*`。不要在生产环境省略，否则能直连 oauth2-proxy 的请求方可能伪造 Host、Proto 或原始 URI |


### PR DESCRIPTION
## Summary
- Make the CSRF Cookie SameSite setting explicit in the Keycloak + oauth2-proxy minimal deployment example.
- Explain that `--cookie-csrf-samesite` defaults to inheriting the session Cookie setting, reducing configuration drift during later changes.

## Changed files
- `content/docs/solution-blogs/keycloak-oauth2-proxy.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc
- https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/

## SEO/GEO impact
Adds a directly reusable configuration and a precise explanation for the `csrf cookie not found` / SameSite troubleshooting intent without adding a new page or keyword-only content.

## Validation
- `npm install`
- `npm run build` passed with Hugo 0.164.0 and Node v26.3.0.
- `git diff --check` passed.

## Risk/rollback
Low risk: documentation-only change. Revert the commit or remove the explicit flag; the documented default remains inheritance from the session Cookie setting. Existing build warnings are unchanged and unrelated.
