### PR TITLE
docs: refresh oauth2-proxy audience guidance

### DIFF
--- a/content/docs/implementation/oauth2-proxy-deep-dive.md
+++ b/content/docs/implementation/oauth2-proxy-deep-dive.md
@@ -166,7 +166,7 @@ oauth2-proxy 和 Keycloak 是最常见组合，但有几个容易踩坑的点：
 
 ### Audience（aud claim）
 
-Keycloak 默认不把 Client ID 写入 access token 的 `aud` 字段。oauth2-proxy v7.4+ 默认验证 audience，不匹配时返回：
+Keycloak 默认不把 Client ID 写入 access token 的 `aud` 字段。oauth2-proxy 的 Keycloak OIDC Provider 会校验 `aud`，并要求其中包含 `--client-id` 或 `--oidc-extra-audience` 配置的值；不匹配时返回：
 
 ```
 {"error": "invalid_token", "error_description": "expected audience \"oauth2-proxy\" got [\"account\"]"}

--- a/content/docs/solution-blogs/keycloak-oauth2-proxy.md
+++ b/content/docs/solution-blogs/keycloak-oauth2-proxy.md
@@ -78,7 +78,7 @@ sequenceDiagram
 
 ### 2. 配置 Audience Mapper（最容易遗漏）
 
-oauth2-proxy v7.4+ 默认验证 ID Token 的 `aud` 字段。Keycloak 默认不把 client ID 写入 audience，导致 `expected audience` 错误。
+oauth2-proxy 的 Keycloak OIDC Provider 会校验 ID Token 的 `aud`（audience），并要求其中包含 `--client-id` 或 `--oidc-extra-audience` 配置的值。Keycloak 客户端如果没有把 oauth2-proxy 的 client ID 写入 `aud`，就会出现 `expected audience` 错误；不要把这个结论绑定到某个旧版本号，实际行为应以所部署版本的 Provider 文档和启动日志为准。
 
 **Protocol Mapper 配置：**
 

--- a/content/docs/solution-blogs/keycloak-redirect-loop-troubleshooting.md
+++ b/content/docs/solution-blogs/keycloak-redirect-loop-troubleshooting.md
@@ -221,7 +221,7 @@ env:
 
 ### Audience 不匹配
 
-oauth2-proxy v7.4+ 默认验证 `aud`（audience）。Keycloak 默认不把 client ID 写入 audience。
+oauth2-proxy 的 Keycloak OIDC Provider 会校验 `aud`（audience），并要求其中包含 `--client-id` 或 `--oidc-extra-audience` 配置的值。Keycloak 客户端如果没有把 oauth2-proxy 的 client ID 写入 `aud`，就会出现 `expected audience` 错误；不要把这个结论绑定到某个旧版本号，实际行为应以所部署版本的 Provider 文档和启动日志为准。
 
 ```json
 // 错误日志


### PR DESCRIPTION
## Summary
- 更新 Keycloak + oauth2-proxy 集成指南中的 audience 校验说明
- 移除绑定旧版本号的表述，明确 `--client-id` / `--oidc-extra-audience` 与 Keycloak Audience Mapper 的对应关系
- 同步修正重定向排错页和 oauth2-proxy 原理页，避免内容簇内出现互相矛盾的版本结论

## Changed files
- `content/docs/solution-blogs/keycloak-oauth2-proxy.md`
- `content/docs/solution-blogs/keycloak-redirect-loop-troubleshooting.md`
- `content/docs/implementation/oauth2-proxy-deep-dive.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://github.com/oauth2-proxy/oauth2-proxy/issues/2808

## SEO/GEO impact
- 强化 IAM 网关、Keycloak oauth2-proxy、expected audience 等真实排错意图的可引用答案块。
- 保持既有 title、description、内链和章节结构不变，避免关键词堆砌。

## Validation
- `npm install` passed on Node v26.3.0
- `npm run build` passed with Hugo 0.164.0 extended
- `git diff --check` passed
- Existing Hugo warnings remain: deprecated `css.Sass` and descriptions on taxonomy pages.

## Risk/rollback
- 文档-only 改动，无运行时影响。
- 如需回滚，revert the squash merge commit; no deployment rollback is required.
