### PR TITLE
docs: fix IAM architecture cross references

### DIFF
--- a/content/docs/advanced-topics/iam-architecture-design.md
+++ b/content/docs/advanced-topics/iam-architecture-design.md
@@ -221,7 +221,7 @@ graph TB
 
 ### 零信任 IAM 架构
 
-零信任的核心原则是"永不信任，始终验证"。IAM 在零信任中承担持续认证和动态授权的角色。关于零信任的完整论述见[第24章]({{< relref "docs/advanced-topics/zero-trust-identity.md" >}})，这里聚焦 IAM 架构如何在零信任中落地。
+零信任的核心原则是"永不信任，始终验证"。IAM 在零信任中承担持续认证和动态授权的角色。关于零信任的完整论述见[第24章]({{< relref "zero-trust-identity" >}})，这里聚焦 IAM 架构如何在零信任中落地。
 
 ```mermaid
 graph TB
@@ -244,7 +244,7 @@ graph TB
     style IDP fill:#9cf,stroke:#333
 ```
 
-在这个架构中，IAM 系统承担的角色从"登录时验证一次"变为"为访问决策持续提供身份上下文"。但不要把 JWT 本地验签误写成持续验证：本地验签不会感知即时会话吊销；高风险操作才应按需调用 Token Introspection 或策略引擎。具体取舍见[零信任 IAM 中 JWT 与 Introspection 的边界]({{< relref "docs/advanced-topics/zero-trust-identity.md" >}})。
+在这个架构中，IAM 系统承担的角色从"登录时验证一次"变为"为访问决策持续提供身份上下文"。但不要把 JWT 本地验签误写成持续验证：本地验签不会感知即时会话吊销；高风险操作才应按需调用 Token Introspection 或策略引擎。具体取舍见[零信任 IAM 中 JWT 与 Introspection 的边界]({{< relref "zero-trust-identity" >}})。
 
 ### 混合云 IAM 架构
 
@@ -347,7 +347,7 @@ IAM 是高可用要求最高的基础设施之一——如果 IAM 挂了，所�
 | Introspection / 策略引擎 | 高风险操作、即时吊销、需要实时设备或风险上下文 | 每次或按需依赖 IAM 网络可用性，需设置超时、缓存和降级策略 |
 | IAM 会话 + 短期 Access Token | 浏览器登录、需要集中注销的场景 | 仍需正确处理 Cookie、代理 Header 和节点间缓存一致性 |
 
-这也是为什么“JWT 无状态化”不能替代 IAM 的灾备设计：它只降低资源服务器对在线校验的依赖，不会让登录、刷新令牌和管理员操作在 IAM 故障时自动可用。具体的 JWT 与 Introspection 边界见[零信任 IAM 中 JWT 与 Introspection 的边界]({{< relref "docs/advanced-topics/zero-trust-identity.md" >}})。
+这也是为什么“JWT 无状态化”不能替代 IAM 的灾备设计：它只降低资源服务器对在线校验的依赖，不会让登录、刷新令牌和管理员操作在 IAM 故障时自动可用。具体的 JWT 与 Introspection 边界见[零信任 IAM 中 JWT 与 Introspection 的边界]({{< relref "zero-trust-identity" >}})。
 
 对内部 Web 应用采用网关认证时，还要把“入口认证”和“资源授权”拆开验证：例如 [Keycloak + oauth2-proxy 集成指南]({{< relref "../solution-blogs/keycloak-oauth2-proxy" >}}) 中的 `/oauth2/auth` 只回答请求是否有有效会话，后端若消费 Access Token 仍需按资源服务器规则校验 `iss`、`aud` 和权限。否则 IAM 架构图看起来是闭环，实际授权边界却在反向代理的一个 Header 上。
 
@@ -357,7 +357,7 @@ IAM 是高可用要求最高的基础设施之一——如果 IAM 挂了，所�
 - **备份**：备份数据库、Realm/客户端配置、密钥材料和部署清单；只备份数据库而没有密钥，恢复后可能无法验证旧令牌或解密凭据。
 - **恢复演练**：至少验证“数据库故障”“单节点故障”“整套 IAM 恢复”三条路径，并记录 RTO/RPO，而不是只检查备份文件是否生成。
 
-> **Keycloak 部署提示**：反向代理、缓存/集群和数据库是三个独立故障域。先按[Keycloak 高可用集群与容灾恢复指南]({{< relref "docs/solution-blogs/keycloak-ha-dr.md" >}})验证单节点故障，再引入跨可用区或跨集群方案。参考 Keycloak 的[反向代理配置文档](https://www.keycloak.org/server/reverseproxy)和[缓存配置文档](https://www.keycloak.org/server/caching)，不要把通用 IAM 经验直接套成 Keycloak 参数。
+> **Keycloak 部署提示**：反向代理、缓存/集群和数据库是三个独立故障域。先按[Keycloak 高可用集群与容灾恢复指南]({{< relref "../solution-blogs/keycloak-ha-dr" >}})验证单节点故障，再引入跨可用区或跨集群方案。参考 Keycloak 的[反向代理配置文档](https://www.keycloak.org/server/reverseproxy)和[缓存配置文档](https://www.keycloak.org/server/caching)，不要把通用 IAM 经验直接套成 Keycloak 参数。
 
 ## 常见误区
 
@@ -420,10 +420,10 @@ IAM 是高可用要求最高的基础设施之一——如果 IAM 挂了，所�
 
 ## 小结
 
-IAM 架构设计不是一次性决策。组织在成长，应用在增加，安全要求在变化——IAM 架构需要跟着演进。从中心化到联邦，从单体到多租户，每一步都是对"身份数据归谁管、认证决策谁来做、故障来了怎么办"这三个问题的重新回答。多租户场景下的隔离模式详解，参见 [多租户 IAM 架构设计与方案对比]({{< relref "docs/advanced-topics/multi-tenant-iam.md" >}})。
+IAM 架构设计不是一次性决策。组织在成长，应用在增加，安全要求在变化——IAM 架构需要跟着演进。从中心化到联邦，从单体到多租户，每一步都是对"身份数据归谁管、认证决策谁来做、故障来了怎么办"这三个问题的重新回答。多租户场景下的隔离模式详解，参见 [多租户 IAM 架构设计与方案对比]({{< relref "multi-tenant-iam" >}})。
 
 选架构时记住：简单够用 > 超前设计。一个维护良好的单实例 Keycloak，比一个没人能调通的微服务 IAM 栈有价值得多。
 
-> **架构选好了，协议怎么选？** 协议和架构是 IAM 的两个决策维度——协议决定"用什么语言"传递身份信息，架构决定"用什么结构"组织身份系统。继续阅读 [IAM 协议选型指南]({{< relref "docs/advanced-topics/iam-protocol-selection-guide.md" >}})，用决策树确定 OAuth 2.0、OIDC、SAML、LDAP、SCIM 在你架构中的角色。
+> **架构选好了，协议怎么选？** 协议和架构是 IAM 的两个决策维度——协议决定"用什么语言"传递身份信息，架构决定"用什么结构"组织身份系统。继续阅读 [IAM 协议选型指南]({{< relref "iam-protocol-selection-guide" >}})，用决策树确定 OAuth 2.0、OIDC、SAML、LDAP、SCIM 在你架构中的角色。
 >
-> **架构和协议都定了，用哪个开源 IAM？** 参见 [开源 IAM 对比与选型指南]({{< relref "docs/advanced-topics/opensource-iam-comparison.md" >}})——Keycloak、Casdoor、Zitadel、Authentik、Ory、Dex、CAS 的功能矩阵与场景推荐。
+> **架构和协议都定了，用哪个开源 IAM？** 参见 [开源 IAM 对比与选型指南]({{< relref "opensource-iam-comparison" >}})——Keycloak、Casdoor、Zitadel、Authentik、Ory、Dex、CAS 的功能矩阵与场景推荐。

--- a/content/docs/advanced-topics/zero-trust-identity.md
+++ b/content/docs/advanced-topics/zero-trust-identity.md
@@ -38,7 +38,7 @@ toc: true
 >
 > （这一口号源自 John Kindervag / Forrester 2010 的零信任早期表述；NIST SP 800-207 将其具化为：不基于网络位置给予隐式信任、显式验证、最小权限、假设已沦陷等原则。）
 
-零信任不是一种产品，而是一种安全架构理念。在 IAM（身份与访问管理）体系中，零信任将"身份"提升为安全决策的核心依据——这与传统 IAM 以"认证通过后放行"的模式有根本区别。IAM 架构的整体设计思路可参考 [IAM 架构设计指南]({{< relref "docs/advanced-topics/iam-architecture-design.md" >}})。
+零信任不是一种产品，而是一种安全架构理念。在 IAM（身份与访问管理）体系中，零信任将"身份"提升为安全决策的核心依据——这与传统 IAM 以"认证通过后放行"的模式有根本区别。这里的参考模型依据 [NIST SP 800-207](https://doi.org/10.6028/NIST.SP.800-207)；IAM 架构的整体设计思路可参考 [IAM 架构设计指南]({{< relref "iam-architecture-design" >}})。
 
 | 传统安全 | 零信任安全 |
 |---------|-----------|
@@ -101,7 +101,7 @@ graph TD
 | 调用 Token Introspection | 可读取当前 token 的 `active` 状态，适合高风险操作 | 增加 IAM 依赖、延迟和容量压力；必须设计超时和降级策略 |
 | 短有效期 JWT + 风险事件触发撤销 | 在性能与撤销速度之间折中 | 需要事件分发、缓存失效和可观测性，不能只改 token TTL |
 
-实践上，可以把普通读请求交给本地验签，把转账、改权限、导出数据等高风险操作交给 introspection 或独立策略引擎二次决策。若使用 introspection，资源服务器应设置明确的超时和“拒绝优先”策略，避免 IAM 故障被错误地当成允许访问。Keycloak 的 introspection 配置示例见 [OAuth 2.0 Token Introspection 实战指南]({{< relref "docs/solution-blogs/oauth2-token-introspection-guide.md" >}})。
+实践上，可以把普通读请求交给本地验签，把转账、改权限、导出数据等高风险操作交给 introspection 或独立策略引擎二次决策。若使用 introspection，资源服务器应设置明确的超时和“拒绝优先”策略，避免 IAM 故障被错误地当成允许访问。Keycloak 的 introspection 配置示例见 [OAuth 2.0 Token Introspection 实战指南]({{< relref "../solution-blogs/oauth2-token-introspection-guide" >}})。
 
 还有一个不同层次的防护：**sender-constrained token**。OAuth DPoP（RFC 9449）让客户端用私钥对请求生成证明，使窃取到的 bearer token 更难被另一台设备直接重放；它不能替代 `iss`、`aud`、过期时间和权限校验，也不能单独解决被攻陷客户端的问题。需要抗重放的 API，才值得承担密钥管理和代理兼容性的额外复杂度。
 
@@ -119,7 +119,7 @@ graph TD
 - 权限定期审查
 - 网络微隔离（应用间也做认证）
 
-权限模型的选择直接影响零信任的落地效果，RBAC、ABAC、ReBAC 各有适用场景，详见 [IAM 授权模型对比]({{< relref "docs/advanced-topics/authorization-models.md" >}})。
+权限模型的选择直接影响零信任的落地效果，RBAC、ABAC、ReBAC 各有适用场景，详见 [IAM 授权模型对比]({{< relref "authorization-models" >}})。
 
 ### 支柱三：持续验证
 
@@ -128,7 +128,7 @@ graph TD
 - 风险变化时主动吊销 Session/Token
 - 异常行为检测
 
-IAM 会话管理是实现持续验证的关键机制，包括 Token 刷新、吊销和会话生命周期控制，详见 [IAM 会话管理]({{< relref "docs/advanced-topics/iam-session-management.md" >}})。
+IAM 会话管理是实现持续验证的关键机制，包括 Token 刷新、吊销和会话生命周期控制，详见 [IAM 会话管理]({{< relref "iam-session-management" >}})。
 
 ### 支柱四：加密无处不在
 
@@ -243,7 +243,7 @@ graph LR
 | 强认证 | MFA、FIDO2、Passkey | Keycloak WebAuthn / 自定义 SPI |
 | 身份属性 | 用户属性、组、角色 | LDAP Federation / SCIM 同步 |
 | 设备信任 | 设备注册、设备属性 | Keycloak Device Representation |
-|| 自适应策略 | 风险评分、上下文感知 | Keycloak Authenticator SPI / 参见 [IAM 条件访问策略设计]({{< relref "docs/advanced-topics/iam-conditional-access.md" >}}) |
+|| 自适应策略 | 风险评分、上下文感知 | Keycloak Authenticator SPI / 参见 [IAM 条件访问策略设计]({{< relref "iam-conditional-access" >}}) |
 | 持续验证 | CAE、Token 吊销 | Session 管理 / Token Introspection |
 | 审计追踪 | 认证审计、访问日志 | Event Listener SPI / SIEM 对接 |
 
@@ -292,7 +292,7 @@ graph LR
 
 **Q1: 零信任 IAM 架构和传统 IAM 架构的核心区别是什么？**
 
-传统 IAM 架构以"一次认证，全程信任"为默认假设——用户登录后获得 Session/Token，在过期前可以持续访问。零信任 IAM 架构要求每次访问都重新评估：即使用户已经登录，如果设备合规状态变化、地理位置异常或行为出现偏差，策略引擎可以要求重新认证或直接阻断访问。简单说：传统 IAM 管"谁能进来"，零信任 IAM 管"每次请求是否还值得信任"。详细架构设计参见 [IAM 架构设计指南]({{< relref "docs/advanced-topics/iam-architecture-design.md" >}})。
+传统 IAM 架构以"一次认证，全程信任"为默认假设——用户登录后获得 Session/Token，在过期前可以持续访问。零信任 IAM 架构要求每次访问都重新评估：即使用户已经登录，如果设备合规状态变化、地理位置异常或行为出现偏差，策略引擎可以要求重新认证或直接阻断访问。简单说：传统 IAM 管"谁能进来"，零信任 IAM 管"每次请求是否还值得信任"。详细架构设计参见 [IAM 架构设计指南]({{< relref "iam-architecture-design" >}})。
 
 **Q2: 企业 IAM 系统如何落地零信任的持续验证？**
 
@@ -324,7 +324,7 @@ Keycloak 不做 PEP（策略执行点），这一层通常由网关/代理（如
 
 **Q4: 零信任 IAM 和等保 2.0 的关系是什么？**
 
-等保 2.0 对身份鉴别、访问控制、安全审计的要求与零信任 IAM 高度契合。例如等保三级要求"采用两种或两种以上组合的鉴别技术"（对应零信任的 MFA）、"对主体、客体进行安全标记"（对应身份属性驱动决策）、"对系统资源访问的申请和授予应进行持续跟踪和监控"（对应持续验证与审计）。将 IAM 系统从"合规需要的认证模块"提升为"零信任架构的核心引擎"，是满足等保要求同时提升安全实质的有效路径。详见 [IAM 等保合规指南]({{< relref "docs/advanced-topics/iam-compliance-dengbao.md" >}})。
+等保 2.0 对身份鉴别、访问控制、安全审计的要求与零信任 IAM 高度契合。例如等保三级要求"采用两种或两种以上组合的鉴别技术"（对应零信任的 MFA）、"对主体、客体进行安全标记"（对应身份属性驱动决策）、"对系统资源访问的申请和授予应进行持续跟踪和监控"（对应持续验证与审计）。将 IAM 系统从"合规需要的认证模块"提升为"零信任架构的核心引擎"，是满足等保要求同时提升安全实质的有效路径。详见 [IAM 等保合规指南]({{< relref "iam-compliance-dengbao" >}})。
 
 **Q5: 中小企业如何以最低成本启动零信任 IAM？**
 


### PR DESCRIPTION
## Summary
- 修正 IAM 架构与零信任章节中跨目录 relref 的写法，避免把站点路径当作当前页面相对路径。
- 在零信任章节补充 NIST SP 800-207 参考模型的直接来源链接。

## Changed files
- `content/docs/advanced-topics/iam-architecture-design.md`
- `content/docs/advanced-topics/zero-trust-identity.md`

## Technical sources
- https://doi.org/10.6028/NIST.SP.800-207
- https://www.rfc-editor.org/rfc/rfc7644
- https://www.keycloak.org/server/reverseproxy
- https://www.keycloak.org/server/caching

## SEO/GEO impact
- 保留 IAM、零信任 IAM、Keycloak 等自然术语和原有内容结构。
- 修复两个高权重 IAM 页面中的站内交叉引用，降低相关内容无法解析的风险，增强 IAM 内容簇的可爬取性。

## Validation
- `npm install` ✅
- `npm run build` ✅（Hugo 0.164.0；仅有既存 Sass/description warnings）
- `git diff --check` ✅

## Risk/rollback
- 风险低：仅调整 relref 参数和补充一个权威来源链接，不改变运行配置或协议结论。
- 回滚：revert 此 PR 即可。