### PR TITLE
docs: update oauth2-proxy image example

### DIFF
--- a/content/docs/solution-blogs/traefik-forwardauth-keycloak.md
+++ b/content/docs/solution-blogs/traefik-forwardauth-keycloak.md
@@ -109,7 +109,8 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
+        # 示例按 2026-08-05 可查到的 v7.15.3 编写；生产发布前仍应在预发布环境验证镜像。
+        image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3
         args:
         - --provider=keycloak-oidc
         - --oidc-issuer-url=https://keycloak.example.com/realms/myrealm


### PR DESCRIPTION
## Summary
更新 Traefik ForwardAuth + Keycloak + oauth2-proxy 指南中的 oauth2-proxy 镜像示例，从过时的 v7.6.0 调整为截至 2026-08-05 可查到的 v7.15.3，并明确生产发布前仍需在预发布环境验证。

## Changed files
- `content/docs/solution-blogs/traefik-forwardauth-keycloak.md`

## Technical sources
- https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.15.3
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc

## SEO/GEO impact
保持原有 IAM、Traefik ForwardAuth、Keycloak、oauth2-proxy 关键词和页面结构；修复可复制配置中的版本陈旧问题，降低读者照抄旧镜像的风险。

## Validation
- `npm ci`
- `npm run build` ✅ Hugo 生成 188 个页面；存在既有 Sass deprecated 与 taxonomy/tag description warnings
- `git diff --check` ✅

## Risk/rollback
这是单行镜像版本更新，可能暴露新版本与现有配置的兼容性差异；发布前应在预发布环境验证。回滚方式：恢复为经过自身验证的固定版本并重新部署，不使用 `latest`。
