### PR TITLE
docs: make oauth2-proxy discovery check portable

### DIFF
--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -227,9 +227,15 @@ PY
 **最快的排错方式**：
 
 ```bash
-# 1. 确认 oauth2-proxy 能否正确连接 Keycloak OIDC Discovery
-kubectl exec -n auth deploy/oauth2-proxy -- wget -qO- \
-  https://keycloak.example.com/realms/myrealm/.well-known/openid-configuration 2>&1 | head
+# 1. 从集群网络路径确认 oauth2-proxy 能否访问 OIDC Discovery
+# 不要默认 oauth2-proxy 镜像内含 wget/curl；用一次性排错 Pod，或换成集群已有的 debug 容器。
+kubectl run oidc-debug --rm -i --restart=Never \
+  --image=curlimages/curl:8.10.1 -- \
+  -fsS https://keycloak.example.com/realms/myrealm/.well-known/openid-configuration \
+  | jq '{issuer, authorization_endpoint, token_endpoint, jwks_uri}'
+
+# 如果集群禁止临时 Pod，使用已经存在的网络诊断容器执行同一 curl；
+# 关键是测试路径、DNS 和 CA 信任，而不是测试 oauth2-proxy 容器是否带 wget。
 
 # 2. 用浏览器 DevTools 跟踪完整流程
 # Network 面板 → 勾选 Preserve log


### PR DESCRIPTION
## Summary
修正 IAM 网关 oauth2-proxy 排错指南中的 OIDC Discovery 诊断命令：不再假定生产镜像内置 `wget`，改用一次性 curl debug Pod，并明确从集群网络路径验证 DNS、路径和 CA 信任。

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc
- https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/

## SEO/GEO impact
保留现有 IAM、oauth2-proxy、Keycloak、OIDC 排错意图；增加可直接执行且不依赖特定容器工具的验证步骤，提升排错答案的可复现性。

## Validation
- `npm ci`
- `npm run build` passed (188 pages)
- `git diff --check` passed

Build warnings are pre-existing: Hugo `css.Sass` deprecation and short descriptions on generated taxonomy pages.

## Risk/rollback
低风险，仅修改文档命令。若集群策略禁止临时 Pod，使用已有 debug 容器执行同一 curl；回滚可恢复原文档命令或 revert 本 PR。
