### PR TITLE
docs: clarify oauth2-proxy audience token scope

### DIFF
--- a/content/blog/keycloak-oauth2-proxy-ingress-forwardauth.md
+++ b/content/blog/keycloak-oauth2-proxy-ingress-forwardauth.md
@@ -76,7 +76,7 @@ curl -fsS https://sso.example.test/realms/internal/.well-known/openid-configurat
 
 然后补两个 mapper：
 
-1. **Audience mapper**：把 `Included Client Audience` 设置为 `oauth2-proxy`。否则 oauth2-proxy 校验 access token 时常见 `expected audience` / `invalid aud`，日志里可能只看到 `account`。
+1. **Audience mapper**：把 `Included Client Audience` 设置为 `oauth2-proxy`。oauth2-proxy 的 OIDC 登录回调主要校验 ID Token 的 `aud`；如果只在 access token 上增加 audience，回调仍可能报 `expected audience` / `invalid aud`，日志里常见只看到 `account`。除非后端确实需要该 claim，否则不要为了代理登录把 audience 无条件加到 access token。
 2. **Group Membership mapper**：把组写入 `groups` claim。若只按 realm role 控制，也可以用 oauth2-proxy 的 Keycloak OIDC provider role 选项，但 groups 更容易给 Ingress/后端统一消费。
 
 生产环境建议单独建 Client，不要复用业务系统 Client。Client Secret 按密钥管理系统下发，轮换时先让 oauth2-proxy 支持新 Secret，再撤旧 Secret；别在发布窗口玩盲盒。
@@ -254,7 +254,7 @@ printf '%s' "$TOKEN" | cut -d. -f2 | base64 -d 2>/dev/null | jq '.aud,.groups'
 
 | 症状 / 日志 | 常见根因 | 修正方式 |
 |---|---|---|
-| `expected audience` / `invalid aud`，`aud` 里只有 `account` | Keycloak access token 没包含 oauth2-proxy 这个 audience | 在 Keycloak Client 增加 Audience mapper；或在 oauth2-proxy 配置额外允许的 audience。优先修 token，不要长期放宽校验。 |
+| `expected audience` / `invalid aud`，`aud` 里只有 `account` | oauth2-proxy 校验的 ID Token 没包含其 client ID | 在 Keycloak Client 增加 Audience mapper，至少勾选 **Add to ID token**；后端确实验证 Access Token 时再单独勾选 **Add to access token**。或在 oauth2-proxy 配置额外允许的 audience，但不要长期放宽校验。 |
 | 登录成功后反复跳转 | `redirect_url`、Ingress `auth-signin`、cookie domain 或 SameSite 与真实入口不一致 | 固定 `redirect_url=https://app.example.test/oauth2/callback`；跨子域再设置 `.example.test` cookie domain；检查外部 HTTPS 入口。 |
 | `csrf cookie not found` | 回调域名和发起登录域名不一致，或 cookie 被浏览器拒收 | 统一 host；启用 HTTPS；检查 `cookie_secure`、`cookie_samesite`、`cookie_domains`。 |
 | `/oauth2/auth` 一直 401 | 浏览器没有带 oauth2-proxy session cookie，或请求没有走同一个 host | 先确认 `/oauth2/callback` 是否成功 Set-Cookie，再查 Ingress/Traefik 路由是否共用同一 host。 |

--- a/content/docs/keycloak/integrations/index.md
+++ b/content/docs/keycloak/integrations/index.md
@@ -171,7 +171,7 @@ spec:
 
 | 症状 / 报错 | 常见根因 | 修正方式 |
 |-------------|----------|----------|
-| `expected audience` / `invalid aud`，日志里只有 `account` | Keycloak access token 的 `aud` 没有包含 oauth2-proxy 的 `client_id` | 在 Keycloak Client 增加 **Audience mapper**，把 `Included Client Audience` 设为 `oauth2-proxy`；或在 oauth2-proxy 显式配置 `--oidc-extra-audience`。 |
+| `expected audience` / `invalid aud`，日志里只有 `account` | oauth2-proxy 校验的 ID Token `aud` 没有包含其 `client_id` | 在 Keycloak Client 增加 **Audience mapper**，至少勾选 **Add to ID token**，把 `Included Client Audience` 设为 `oauth2-proxy`；只有后端确实验证 Access Token 时才额外勾选 **Add to access token**。也可在 oauth2-proxy 显式配置 `--oidc-extra-audience`，但不要用它掩盖错误的 Token 受众。 |
 | 登录后反复跳转 / `csrf cookie not found` | `redirect_url`、Ingress `auth-signin`、Cookie Domain / SameSite 与实际访问域名不一致 | `redirect_url` 固定为外部入口 `https://app.example.com/oauth2/callback`；Ingress 使用 `$host` 与 `$escaped_request_uri`；跨子域共享时再设置 `--cookie-domain=.example.com`。 |
 | `/oauth2/auth` 返回 401，但用户已登录 | 业务 Ingress 没把认证响应头传给后端，或 oauth2-proxy 未开启 header 输出 | oauth2-proxy 开启 `--set-xauthrequest=true`；NGINX Ingress 用 `auth-response-headers` 透传 `X-Auth-Request-User`、`X-Auth-Request-Email`、`X-Auth-Request-Groups`。 |
 | Keycloak 回调到 `http://` 或错误 host | Keycloak / oauth2-proxy 后面有反向代理，但 `X-Forwarded-*` 头或 proxy 配置缺失 | 入口层保留 `X-Forwarded-Proto`、`X-Forwarded-Host`；Keycloak 侧按生产反向代理章节配置 hostname/proxy headers。 |


### PR DESCRIPTION
## Summary
- Clarify that oauth2-proxy's OIDC callback audience check concerns the ID Token.
- Separate the ID Token mapper requirement from the optional Access Token audience used by a backend.
- Align the integration troubleshooting table with the solution guide.

## Changed files
- `content/blog/keycloak-oauth2-proxy-ingress-forwardauth.md`
- `content/docs/keycloak/integrations/index.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/
- https://github.com/oauth2-proxy/oauth2-proxy/issues/3463

## SEO/GEO impact
Improves the answer block for IAM / Keycloak / oauth2-proxy `expected audience` searches by distinguishing ID Token and Access Token diagnostics, reducing a common misleading configuration path.

## Validation
- `npm ci`
- `npm run build` (passed; existing Hugo warnings remain for deprecated `css.Sass` and empty taxonomy descriptions)
- `git diff --check`

## Risk/rollback
Documentation-only change. Revert the merge commit to roll back; no runtime configuration or dependency changes are included.
