### PR TITLE
docs: explain Traefik oauth2-proxy CSRF race

### DIFF
--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -119,6 +119,18 @@ args:
 
 `--cookie-csrf-per-request-limit` 只有在 `--cookie-csrf-per-request=true` 时生效；它限制 oauth2-proxy 保留的并行 CSRF Cookie 数量，超出后删除最早的 Cookie。先不设置上限通常更容易验证根因，但生产环境应结合浏览器并发行为和代理 Header 大小限制决定是否加上限。改动后清理旧 Cookie，再用两个标签页同时访问受保护 URL，确认两次回调都能完成；若出现 431，回到上限、Cookie Domain 和代理 Header 限制一起检查。
 
+### Traefik `errors` 中间件造成的并发 CSRF 覆盖
+
+如果使用 Traefik `ForwardAuth`，再用 `errors` 中间件把 401 重定向到 `/oauth2/sign_in`，不要只测试“点击登录”这一条路径。页面加载时的 JavaScript、CSS、favicon 或 Service Worker 可能同时触发多个未认证请求；在 `--skip-provider-button=true` 时，这些请求可能各自启动授权流程并反复写入 CSRF Cookie。最后一个 Cookie 与浏览器正在完成的较早授权请求不匹配，就会得到 `CSRF token mismatch`，看起来像随机故障，实际是竞态。
+
+先看浏览器 Network 面板和 oauth2-proxy 访问日志：如果一次页面加载出现多个 `/oauth2/start` 或 `/oauth2/sign_in`，并且它们连续返回 `Set-Cookie: _oauth2_proxy_csrf=...`，就不要先改 SameSite 或加 Redis。可控的修复顺序是：
+
+1. 暂时将 `--skip-provider-button=false`，让 `/oauth2/sign_in` 只展示登录页，由用户的一次明确导航触发 `/oauth2/start`；这是降低并发启动的诊断和缓解措施，不是对所有代理拓扑的永久保证。
+2. 在确认确实需要并行授权后，再启用 `--cookie-csrf-per-request=true`，并按代理 Header 大小设置 `--cookie-csrf-per-request-limit`；不要无限制地把 Cookie 数量调大。
+3. 把静态资源和 Service Worker 的未认证请求从错误重定向链路中排除，或让入口只对页面导航触发登录。验证时保留浏览器 Network 日志，确认一次登录只产生预期的授权请求。
+
+这个现象已有 oauth2-proxy issue [#3463](https://github.com/oauth2-proxy/oauth2-proxy/issues/3463) 的复现记录；该 issue 报告的版本和 Traefik 版本属于具体案例，不能据此推断所有版本都相同。最终应以所部署版本的行为为准。关于子域名场景下 CSRF Cookie 不出现的另一类排查线索，可参阅 [Stack Overflow 问题](https://stackoverflow.com/questions/77504002/oauth2-proxy-and-subdomains-unable-to-obtain-csrf-cookie)，但不要把社区问答当作配置规范。
+
 > **常见误区**：看到多副本就立刻加 Redis。这里有一个容易把排错方向带偏的细节：**默认 Cookie Session Store 并不要求回调落到同一个 Pod**。只要多个副本使用相同的 `--cookie-secret`，各副本都能解密由其他副本签发的会话 Cookie；把“多副本”直接等同于“必须上 Redis”会平白增加一个运行依赖。当前 oauth2-proxy 文档将 `cookie` 列为默认 Session Store，`redis` 是另一种可选后端。
 
 只有在以下情况才优先考虑 Redis：Cookie 体积超过浏览器或代理限制、需要服务端集中撤销会话，或希望不把 OAuth Token 放进 Cookie。迁移时先保留相同的外部回调地址和 Cookie 参数，在灰度副本上启用 Redis，并为 Redis 配置 TLS、认证、超时和监控；不要把 `--redis-insecure-skip-tls-verify=true` 当成生产修复。最小配置形态如下（连接字符串和密码放 Secret，不要写入 Git）：

--- a/content/docs/solution-blogs/traefik-forwardauth-keycloak.md
+++ b/content/docs/solution-blogs/traefik-forwardauth-keycloak.md
@@ -72,6 +72,14 @@ sequenceDiagram
 
 Keycloak 端的客户端创建、Audience Mapper 配置、角色映射等步骤与 Nginx Ingress 方案完全一致。详细步骤参考 [Keycloak + oauth2-proxy 集成指南 — Keycloak 端配置]({{< relref "keycloak-oauth2-proxy#keycloak-端配置" >}})，这里只强调 Traefik 场景下容易遗漏的两个点：
 
+### 不要让 `errors` 中间件并发启动登录
+
+如果用 `errors` 中间件把 ForwardAuth 的 401 改写到 `/oauth2/sign_in`，并且设置了 oauth2-proxy 的 `--skip-provider-button=true`，页面中的多个静态资源请求可能同时启动 OIDC 流程。每次启动都会写一个 CSRF Cookie，后写入的 Cookie 可能覆盖先前请求对应的 Cookie，回调时就会出现 `CSRF token mismatch`。
+
+排错时先在浏览器 Network 面板和 oauth2-proxy 日志中确认是否有多个 `/oauth2/start` 或 `/oauth2/sign_in`。优先用 `--skip-provider-button=false` 做对照，让用户点击一次登录，再决定是否启用 `--cookie-csrf-per-request=true`；后者会增加请求头体积，应结合 `--cookie-csrf-per-request-limit`、Ingress Header 限制和实际并发量验证。静态资源不应被错误重定向链路反复触发登录。
+
+该竞态有 [oauth2-proxy issue #3463](https://github.com/oauth2-proxy/oauth2-proxy/issues/3463) 的复现记录；issue 中的版本组合是案例，不是对所有版本的兼容性结论。oauth2-proxy 的当前配置说明了 `skip-provider-button` 和 `cookie-csrf-per-request` 的语义，最终仍应在实际版本上回归。
+
 ### redirect_uri 配置
 
 Traefik 场景下，oauth2-proxy 的回调地址是 `https://<你的域名>/oauth2/callback`——与 Nginx Ingress 模式完全一样。oauth2-proxy 默认用请求的 `Host` 头构造 redirect_uri，所以在 Keycloak Client 配置中需要把所有受保护域名的 callback 路径都加上：


### PR DESCRIPTION
## Summary
补充 Traefik `ForwardAuth` + `errors` 中间件触发 oauth2-proxy 并发 OIDC 登录、覆盖 CSRF Cookie 的排错说明。

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`
  - 增加并发 CSRF 覆盖的症状、诊断顺序、缓解与验证步骤。
- `content/docs/solution-blogs/traefik-forwardauth-keycloak.md`
  - 在 Traefik 集成页补充同一竞态的配置边界和回归建议。

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://github.com/oauth2-proxy/oauth2-proxy/issues/3463
- https://stackoverflow.com/questions/77504002/oauth2-proxy-and-subdomains-unable-to-obtain-csrf-cookie
- https://www.keycloak.org/server/reverseproxy

## SEO/GEO impact
覆盖 `oauth2-proxy CSRF token mismatch`、`Traefik ForwardAuth CSRF`、`errors middleware`、`Keycloak oauth2-proxy` 等真实排错意图；补充可直接执行的诊断与回滚边界，没有新增泛化概念页。

## Validation
- `npm ci`：通过
- `npm run build`：通过（188 pages）；保留既有 Hugo Sass deprecated 与 taxonomy description warnings
- `git diff --check`：通过
- 生成 HTML 检查：两个修改页面均包含新增段落

## Risk/rollback
- 改动仅为文档，不改变运行配置。
- 若结论不适用于某个 oauth2-proxy/Traefik 版本，按部署版本回归；issue 中版本组合仅作案例。
- 回滚可 revert 本 PR；生产配置无需变更。
