### PR TITLE
docs: refresh Keycloak 26.7 patch guidance

### DIFF
--- a/content/docs/implementation/kubernetes-production.md
+++ b/content/docs/implementation/kubernetes-production.md
@@ -34,13 +34,13 @@ toc: true
 
 ## 19.2 使用 Keycloak Operator
 
-> 版本提示：Keycloak 官方下载页与 GitHub Release 显示当前稳定版为 `26.7.0`（2026-07-11 检查）；官方 Operator 安装文档同样提供 `26.7.0` 的 `keycloak-k8s-resources` 示例。Keycloak 迭代很快，部署时请到 [keycloak.org/downloads](https://www.keycloak.org/downloads)、[Keycloak Releases](https://github.com/keycloak/keycloak/releases) 与 [Operator 安装文档](https://www.keycloak.org/operator/installation) 复核**当前最新稳定版**，并保持 Operator 版本与 Keycloak 镜像一致。
+> 版本提示：Keycloak 官方 GitHub Release 当前可见的 26.7 补丁版本为 `26.7.1`（2026-08-05 发布）。安装 Operator 时应把 `keycloak-k8s-resources`、CRD 和 Keycloak 镜像固定到同一版本；不要把下面的版本号当作永久答案，部署前仍需复核 [keycloak.org/downloads](https://www.keycloak.org/downloads)、[Keycloak Releases](https://github.com/keycloak/keycloak/releases) 与 [Operator 安装文档](https://www.keycloak.org/operator/installation)。
 
 ### 安装 Operator
 
 ```bash
-# 安装 Operator（示例使用 26.7.0；生产环境请先确认该版本仍是当前稳定版）
-VERSION=26.7.0
+# 安装 Operator（示例使用 26.7.1；生产环境先确认版本与 Operator/CRD 兼容）
+VERSION=26.7.1
 kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
 kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
 kubectl create namespace keycloak
@@ -68,7 +68,7 @@ metadata:
     app: keycloak
 spec:
   instances: 3
-  image: quay.io/keycloak/keycloak:26.7.0   # 示例版本；上线前复核当前稳定版
+  image: quay.io/keycloak/keycloak:26.7.1   # 示例版本；上线前复核当前稳定版
   hostname:
     hostname: auth.example.com
   http:

--- a/content/docs/keycloak/getting-started.md
+++ b/content/docs/keycloak/getting-started.md
@@ -14,7 +14,7 @@ toc: true
 
 [keycloak][] 是一个开源的、面向现代应用和服务的 IAM（身份认证和访问控制）解决方案。
 
-> 自 Keycloak 17 起，官方只发布 **Quarkus 发行版**，旧的 WildFly 发行版已被移除；各类语言专用的 **Client Adapter 也已陆续废弃**，官方推荐直接使用各生态的标准 OIDC/OAuth 2.0/SAML 库对接。如果你还在用旧 Adapter，参考 [Keycloak Adapter 弃用迁移指南]({{< relref "docs/solution-blogs/keycloak-adapter-migration" >}}) 逐语言迁移。Keycloak 版本迭代很快，本书编写时当前稳定版为 26.7.0（2026-07-11 检查），部署前请到 [keycloak.org/downloads](https://www.keycloak.org/downloads) 确认最新版本。关于 Keycloak 架构（Realm / Client / 认证流引擎 / 缓存 / 集群）的深度解析，见[第14章：Keycloak 架构深度解析]({{< relref "docs/implementation/keycloak-architecture.md" >}})。
+> 自 Keycloak 17 起，官方只发布 **Quarkus 发行版**，旧的 WildFly 发行版已被移除；各类语言专用的 **Client Adapter 也已陆续废弃**，官方推荐直接使用各生态的标准 OIDC/OAuth 2.0/SAML 库对接。如果你还在用旧 Adapter，参考 [Keycloak Adapter 弃用迁移指南]({{< relref "docs/solution-blogs/keycloak-adapter-migration" >}}) 逐语言迁移。Keycloak 版本迭代很快，截至 2026-08-15，官方发布页可见的 26.7 补丁版本为 `26.7.1`；部署前请到 [keycloak.org/downloads](https://www.keycloak.org/downloads) 确认最新版本。关于 Keycloak 架构（Realm / Client / 认证流引擎 / 缓存 / 集群）的深度解析，见[第14章：Keycloak 架构深度解析]({{< relref "docs/implementation/keycloak-architecture.md" >}})。
 
 主要功能：
 

--- a/content/docs/solution-blogs/keycloak-26-7-whats-new.md
+++ b/content/docs/solution-blogs/keycloak-26-7-whats-new.md
@@ -12,6 +12,8 @@ menu:
 toc: true
 ---
 
+> **补丁版本更新（2026-08-15）**：本文记录的是 26.7.0 的功能变化；26.7.1 已于 2026-08-05 发布，主要价值是安全修复而不是新增架构能力。官方发布说明列出 JWE request object 签名算法校验绕过、管理权限提升、FGAP v2 权限绕过、SAML/LDAP/DCR 等多项安全修复。生产环境应先阅读 [26.7.1 发布说明](https://github.com/keycloak/keycloak/releases/tag/26.7.1) 和 [升级指南](https://www.keycloak.org/docs/latest/upgrading/index.html)，再安排备份、预发回归和滚动升级；不要把功能页中的 `26.7.0` 示例直接复制到新部署。
+
 ## 场景描述
 
 Keycloak 26.7.0 于 2026 年 7 月 9 日发布，是 26.x 系列中功能密度最高的版本之一。四个核心方向值得关注：**SCIM API 让用户自动配置成为可能**、**多集群 HA 不再依赖外部缓存**、**AuthZEN 和 OpenID SSF 让授权和安全事件标准化**、**SAML Step-up 从预览转正**。如果你正在维护 Keycloak 生产集群，或者评估开源 IAM 方案，这些变化直接影响你的架构决策。

--- a/content/docs/solution-blogs/keycloak-cluster-cache-tuning.md
+++ b/content/docs/solution-blogs/keycloak-cluster-cache-tuning.md
@@ -370,7 +370,7 @@ bin/kc.sh start --cache=ispn --cache-stack=jdbc-ping
 
 ## 参考来源
 
-- [Keycloak Server Guide: Configuring distributed caches](https://www.keycloak.org/server/caching) — Keycloak 26.7.0 官方文档
+- [Keycloak Server Guide: Configuring distributed caches](https://www.keycloak.org/server/caching) — Keycloak 官方文档（部署时按当前版本复核）
 - [Infinispan Configuration Guide](https://infinispan.org/docs/stable/titles/configuring/configuring.html)
 - [Keycloak HA & DR Guide]({{< relref "keycloak-ha-dr" >}})
 - [Keycloak Redis 外部会话缓存]({{< relref "keycloak-redis-session-cache" >}}) — Infinispan 的替代方案，适合 Kubernetes 动态环境


### PR DESCRIPTION
## Summary
Refresh Keycloak 26.7 guidance from 26.7.0 to the currently published 26.7.1 patch release, and add a security-fix note to the 26.7 feature article.

## Changed files
- `content/docs/implementation/kubernetes-production.md`
- `content/docs/keycloak/getting-started.md`
- `content/docs/solution-blogs/keycloak-26-7-whats-new.md`
- `content/docs/solution-blogs/keycloak-cluster-cache-tuning.md`

## Technical sources
- https://github.com/keycloak/keycloak/releases/tag/26.7.1
- https://www.keycloak.org/docs/latest/upgrading/index.html
- https://www.keycloak.org/operator/installation
- https://www.keycloak.org/server/caching

## SEO/GEO impact
Updates the Keycloak Kubernetes / Operator / IAM version guidance and adds a directly citable patch-security boundary without creating a duplicate page.

## Validation
- `npm ci`
- `npm run build` — passed; Hugo emitted existing Sass deprecation and taxonomy description warnings.
- `git diff --check` — passed.

## Risk/rollback
Documentation-only change. Roll back by reverting this commit; no runtime or dependency changes.