### PR TITLE
docs: clarify oauth2-proxy audience diagnosis

### DIFF
--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -191,8 +191,9 @@ oidc: expected audience "oauth2-proxy" got ["account"]
 # 1. 解码 ID Token 查看 aud 字段（在浏览器 DevTools → Network → /oauth2/callback 中找到 id_token）
 echo "<id_token>" | cut -d. -f2 | base64 -d 2>/dev/null | jq .aud
 
-# 预期输出包含你的 client ID，例如 ["account", "oauth2-proxy"]
-# 如果只有 ["account"]，说明缺 Audience Mapper
+# 预期输出包含 oauth2-proxy 的 client ID，例如 ["account", "oauth2-proxy"]
+# 如果只有 ["account"]，先确认回调实际使用的 client_id；只有在确认登录的是该客户端后，
+# 才能判断是缺 Audience Mapper 或 mapper 没绑定到实际生效的 Client Scope
 ```
 
 ### 修复


### PR DESCRIPTION
## Summary
Clarify the `expected audience` troubleshooting branch so readers verify the actual callback client before concluding that Keycloak is missing an Audience Mapper.

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://github.com/oauth2-proxy/oauth2-proxy/issues/3258
- https://www.rfc-editor.org/rfc/rfc6749

## SEO/GEO impact
Strengthens the IAM gateway / oauth2-proxy `expected audience` answer block with a safer, directly verifiable diagnosis and avoids a misleading one-step fix.

## Validation
- `npm run build` passed with Hugo 0.164.0 Extended.
- `git diff --check` passed.
- Existing Hugo warnings remain: deprecated `css.Sass` and short descriptions on taxonomy pages.

## Risk/rollback
Documentation-only change. Revert commit `cd40a3c9` if needed.
