### PR TITLE
docs: refresh Keycloak proxy header guidance

### DIFF
--- a/content/docs/keycloak/security-features/_index.md
+++ b/content/docs/keycloak/security-features/_index.md
@@ -1,6 +1,6 @@
 ---
-title: "Keycloak 安全增强功能"
-description: "Keycloak 安全防护实战：密码策略、暴力破解检测与账号锁定、MFA 多因子认证及安全加固清单"
+title: "Keycloak IAM 安全增强与加固清单 | IDaaS Book"
+description: "Keycloak IAM 安全加固：密码策略、暴力破解检测、MFA/OTP、Token 会话与反向代理配置，适合生产上线检查。"
 date: 2024-04-01T00:00:00+08:00
 draft: false
 weight: 13
@@ -83,7 +83,7 @@ Keycloak 内置基于 **TOTP** 的 OTP 实现，与 Google Authenticator / FreeO
 ### 传输层
 
 - [ ] 全站 HTTPS，由 Nginx/Ingress 终结 TLS，Keycloak 仅监听内部。
-- [ ] 设置 `proxy=passthrough`（Quarkus 版 `KC_PROXY=passthrough` 或 `--proxy passthrough`，旧 WildFly 版对应 `proxy-address-forwarding=true`），正确识别客户端真实 IP（暴力检测/审计依赖）。
+- [ ] Keycloak 26+ 按代理实际发送的格式设置 `KC_PROXY_HEADERS=xforwarded` 或 `forwarded`，并配置固定的 `KC_HOSTNAME`；代理覆盖写入转发头且 Keycloak Service 不允许客户端直连。旧版 `KC_PROXY`/`proxy=edge` 配置不能直接作为新版本默认值。
 - [ ] HSTS、TLS 1.2+，禁用老 cipher。
 
 ### Token 与会话

--- a/content/docs/keycloak/troubleshooting/https-required.md
+++ b/content/docs/keycloak/troubleshooting/https-required.md
@@ -1,6 +1,6 @@
 ---
 title: "Keycloak HTTPS Required 错误与反向代理排错指南 | IDaaS Book"
-description: "Keycloak 报 HTTPS required 或 Invalid redirect_uri 的排查：反向代理 X-Forwarded-* 头与 proxy 配置"
+description: "Keycloak 报 HTTPS required 或 Invalid redirect_uri 的排查：核对 KC_PROXY_HEADERS、KC_HOSTNAME 与反向代理 X-Forwarded-* 头。"
 date: 2024-04-01T00:00:00+08:00
 draft: false
 weight: 1
@@ -27,7 +27,21 @@ Keycloak 各个 Realm 默认的登录设置里，`Require SSL` 为 `external req
 
 1. 配置 https 并使用 https 登录，毫无疑问，这是正确的解决方案。
 
-   生产环境推荐在反向代理 / Ingress 上终结 TLS，并让 Keycloak 以 `proxy=passthrough`（或 `edge`/`reencrypt` 视场景）感知前端协议，详见 [安全增强功能]({{< relref "docs/keycloak/security-features/_index.md" >}})。
+   生产环境可以在反向代理 / Ingress 上终结 TLS，但必须让 Keycloak 解析代理实际写入的头。Keycloak 26+ 使用 `KC_PROXY_HEADERS=xforwarded`（或 `forwarded`），而不是照搬旧版 `proxy=edge`；同时固定公网地址，避免它根据内部请求推断回调地址。详见 [Keycloak 26+ 代理头排错]({{< relref "../../solution-blogs/keycloak-redirect-loop-troubleshooting" >}}) 和[安全增强功能]({{< relref "../security-features/_index.md" >}})。
+
+   例如 TLS 在 Ingress 终结、Keycloak Pod 内使用 HTTP，且 Ingress 覆盖写入 `X-Forwarded-*`：
+
+   ```yaml
+   env:
+   - name: KC_HTTP_ENABLED
+     value: "true"
+   - name: KC_PROXY_HEADERS
+     value: "xforwarded"
+   - name: KC_HOSTNAME
+     value: "https://keycloak.example.com"
+   ```
+
+   如果代理发送的是标准 `Forwarded` 头，把 `KC_PROXY_HEADERS` 改为 `forwarded`；不要混用两种格式。代理必须覆盖而不是追加客户端提交的同名头，并把 Keycloak Service 限制为只能由受信任代理访问。
 
 2. 如果只是测试环境，可以修改 Realm 的设置，`Require SSL` 改为 `none`。
 


### PR DESCRIPTION
## Summary
- 更新 Keycloak HTTPS Required 排错页，补充 Keycloak 26+ `KC_PROXY_HEADERS` / `KC_HOSTNAME` 的最小配置。
- 更新 Keycloak IAM 安全加固清单，移除容易误导新版本部署的旧 `KC_PROXY` 默认建议。

## Changed files
- `content/docs/keycloak/troubleshooting/https-required.md`
- `content/docs/keycloak/security-features/_index.md`

## Technical sources
- https://www.keycloak.org/server/reverseproxy
- https://www.keycloak.org/server/configuration
- https://www.keycloak.org/server/configuration-production

## SEO/GEO impact
- 修正一个包含 IAM 的页面 title/description，覆盖 Keycloak IAM 安全加固与 HTTPS/反向代理排错意图。
- 增加可直接引用的 `KC_PROXY_HEADERS`、`KC_HOSTNAME` 配置块和代理信任边界说明。

## Validation
- `npm ci`
- `npm run build`（通过；Hugo 0.164.0，188 pages）
- `git diff --check`（通过）

## Risk/rollback
- 仅文档改动，无运行时影响。
- 如需回滚，撤销该 PR；不改动现有生产配置。构建仍有既有 `css.Sass` 弃用和 taxonomy description warnings。