### PR TITLE
docs: clarify DID VC IAM boundaries

### DIFF
--- a/content/docs/advanced-topics/iam-architecture-design.md
+++ b/content/docs/advanced-topics/iam-architecture-design.md
@@ -116,7 +116,7 @@ graph TB
 
 ### 去中心化 IAM 架构（DID/VC）
 
-用户自己持有身份凭证（Verifiable Credential），不依赖任何中心化的身份提供者。这是 IAM 的未来方向，依赖 W3C DID 标准和可验证凭证（VC）技术。
+用户把可验证凭证（Verifiable Credential，VC）保存于自己的钱包，在出示时由验证方校验签名、Issuer 信任关系和凭证状态。它可以减少对中心化 IdP 在线登录的依赖，但不等于“没有中心化组件”：签发方、DID 解析服务、状态服务和企业信任治理仍可能是中心化的。DID/VC 是一组身份数据与验证模型，不是可以直接替换企业 IAM 的部署产品。
 
 ```mermaid
 graph LR


### PR DESCRIPTION
## Summary
Clarify the DID/VC section in the IAM architecture guide: a wallet-held VC reduces dependence on interactive IdP login, but does not eliminate issuers, DID resolution, status services, or trust governance. This keeps DID/VC boundaries distinct from an enterprise IAM deployment.

## Changed files
- `content/docs/advanced-topics/iam-architecture-design.md`

## Technical sources
- https://www.w3.org/TR/did-core/
- https://www.w3.org/TR/vc-data-model-2.0/

## SEO/GEO impact
Improves the answer block for “DID/VC 与 IAM 区别” and “去中心化 IAM 是否没有中心化组件”, while retaining the existing IAM architecture page title and internal links. No keyword stuffing or new page added.

## Validation
- `npm ci`
- `npm run build` — passed: 188 pages, 22 non-page files, 85 static files.
- `git diff --check` — passed.
- Existing build warnings remain: deprecated `css.Sass` and short descriptions on generated taxonomy pages.

## Risk/rollback
Documentation-only, no runtime or dependency change. Revert the single commit `809723ec` to roll back.