### PR TITLE
docs: clarify auth request cookie refresh handling

### DIFF
--- a/content/docs/solution-blogs/keycloak-oauth2-proxy.md
+++ b/content/docs/solution-blogs/keycloak-oauth2-proxy.md
@@ -567,5 +567,6 @@ kcadm.sh get clients/<client-id> -r <realm> > client-backup.json
 - [oauth2-proxy 官方文档 — Keycloak OIDC Provider](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc)
 - [oauth2-proxy 官方配置总览](https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/)
 - [ingress-nginx 外部认证示例：auth-url 与 auth-signin](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/)
+- [oauth2-proxy Integration：Nginx auth_request 与 Set-Cookie 分片转发](https://oauth2-proxy.github.io/oauth2-proxy/configuration/integration)
 - [oauth2-proxy Issue #2808：audience 缺失时的错误处理](https://github.com/oauth2-proxy/oauth2-proxy/issues/2808)
 - [Keycloak 反向代理配置](https://www.keycloak.org/server/reverseproxy)

--- a/content/docs/solution-blogs/oauth2-proxy-common-errors.md
+++ b/content/docs/solution-blogs/oauth2-proxy-common-errors.md
@@ -435,6 +435,20 @@ args:
 - --scope=openid   # 只要 openid，不加 email profile（如果不需要的话）
 ```
 
+### auth_request 模式下的一个隐藏问题：Set-Cookie 被截断
+
+如果 oauth2-proxy 使用 Cookie Session Store，并且启用了 `--cookie-refresh`，`/oauth2/auth` 在刷新会话时可能返回新的 `Set-Cookie`。ingress-nginx 的 `auth_request` 默认只把认证结果带回上游，不能自动把所有 `Set-Cookie` 响应头转发给浏览器；Cookie 被拆成多个分片时，只转发第一片也会造成下一次请求认证失败。
+
+这和“Cookie 太大”不是同一个根因：前者是浏览器拒绝或无法保存，后者是认证子请求的响应头没有完整回传。
+
+**处理顺序：**
+
+1. 先在浏览器 Network 面板确认 `/oauth2/auth` 或业务请求的响应是否出现 `Set-Cookie`，并检查是否有 `_oauth2_proxy_1` 等分片。
+2. 如果只有第一片，按 ingress-nginx 官方 `auth_request` 示例显式转发刷新 Cookie 的所有分片；不要只添加一个 `add_header Set-Cookie` 就认为已修复。
+3. 如果 Cookie 长期接近浏览器限制，改用 Redis Session Store 或精简 claims，并把 Redis 的可用性、备份和凭据轮换纳入变更范围。
+
+不要用增大 Nginx buffer 来掩盖 Cookie 分片没有转发的问题；buffer 解决的是代理处理大小，不会替你复制丢失的 `Set-Cookie` 头。
+
 ---
 
 ## 7. 401 已登录但认证被拒


### PR DESCRIPTION
## Summary
- explain the auth_request-specific Set-Cookie refresh failure mode in the oauth2-proxy troubleshooting guide
- link the main Keycloak + oauth2-proxy guide to oauth2-proxy's integration reference

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md`
- `content/docs/solution-blogs/keycloak-oauth2-proxy.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/integration
- https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/keycloak_oidc

## SEO/GEO impact
Adds a concrete IAM gateway troubleshooting answer for `oauth2-proxy` Cookie refresh, `auth_request`, and split `Set-Cookie` headers, with a direct source link. No keyword-only copy was added.

## Validation
- `npm ci`
- `npm run build` passed with existing Hugo warnings only
- `git diff --check` passed
- Markdown frontmatter checks passed

## Risk/rollback
Documentation-only change. Roll back the commit or revert the squash merge; no runtime configuration is changed.