### PR TITLE
docs: clarify oauth2-proxy auth headers

### DIFF
--- a/content/docs/keycloak/integrations/index.md
+++ b/content/docs/keycloak/integrations/index.md
@@ -180,7 +180,7 @@ spec:
 |-------------|----------|----------|
 | `expected audience` / `invalid aud`，日志里只有 `account` | oauth2-proxy 校验的 ID Token `aud` 没有包含其 `client_id` | 在 Keycloak Client 增加 **Audience mapper**，至少勾选 **Add to ID token**，把 `Included Client Audience` 设为 `oauth2-proxy`；只有后端确实验证 Access Token 时才额外勾选 **Add to access token**。也可在 oauth2-proxy 显式配置 `--oidc-extra-audience`，但不要用它掩盖错误的 Token 受众。 |
 | 登录后反复跳转 / `csrf cookie not found` | `redirect_url`、Ingress `auth-signin`、Cookie Domain / SameSite 与实际访问域名不一致 | `redirect_url` 固定为外部入口 `https://app.example.com/oauth2/callback`；Ingress 使用 `$host` 与 `$escaped_request_uri`；跨子域共享时再设置 `--cookie-domain=.example.com`。 |
-| `/oauth2/auth` 返回 401，但用户已登录 | 业务 Ingress 没把认证响应头传给后端，或 oauth2-proxy 未开启 header 输出 | oauth2-proxy 开启 `--set-xauthrequest=true`；NGINX Ingress 用 `auth-response-headers` 透传 `X-Auth-Request-User`、`X-Auth-Request-Email`、`X-Auth-Request-Groups`。 |
+| `/oauth2/auth` 返回 401，但用户已登录 | 业务 Ingress 没把认证响应头传给后端，或 oauth2-proxy 未开启 header 输出 | oauth2-proxy 开启 `--set-xauthrequest=true`；NGINX Ingress 用 `auth-response-headers` 透传 `X-Auth-Request-User`、`X-Auth-Request-Email`、`X-Auth-Request-Groups`。若后端确实需要 Bearer Token，另行配置 `--pass-access-token=true`，并确认入口复制的是 `X-Auth-Request-Access-Token`；不要把 `--pass-authorization-header`（代理直接转发给其 upstream）误当成 `auth_request` 响应头。 |
 | Keycloak 回调到 `http://` 或错误 host | Keycloak / oauth2-proxy 后面有反向代理，但 `X-Forwarded-*` 头或 proxy 配置缺失 | 入口层保留 `X-Forwarded-Proto`、`X-Forwarded-Host`；Keycloak 侧按生产反向代理章节配置 hostname/proxy headers。 |
 | Keycloak 17+ 后 issuer 不匹配 | 仍沿用旧 WildFly 路径 `/auth/realms/<realm>` | 新部署默认使用 `https://kc.example.com/realms/<realm>`；只有旧版本或保留兼容路径时才使用 `/auth/realms/<realm>`。 |
 


### PR DESCRIPTION
## Summary
Clarify the distinction between oauth2-proxy's `--pass-authorization-header` and the headers returned by NGINX `auth_request`, including the required `--pass-access-token` / `X-Auth-Request-Access-Token` path.

## Changed files
- `content/docs/keycloak/integrations/index.md`

## Technical sources
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/integration/
- https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview/
- https://github.com/oauth2-proxy/oauth2-proxy/issues/1617

## SEO/GEO impact
Improves the IAM + Keycloak + oauth2-proxy troubleshooting answer block for the common case where authentication succeeds but the backend does not receive the expected Authorization or identity header. No keyword-only changes.

## Validation
- `npm ci`
- `npm run build` — passed; Hugo emitted existing Sass deprecation and taxonomy/tag description warnings.
- `git diff --check` — passed.

## Risk/rollback
Documentation-only, no runtime risk. Revert the single commit `e63cf9af` if needed.
