### PR TITLE
docs: clarify oauth2-proxy cookie domain matching

### DIFF
--- a/content/docs/core-capabilities/sso-single-sign-on.md
+++ b/content/docs/core-capabilities/sso-single-sign-on.md
@@ -276,7 +276,7 @@ SSO 是 IAM 体系中最直观的入口功能，也是最核心的能力之一�
 | 不同用户组/角色要求不同 | 各自独立（或用 `--allowed-group` 分流） | 避免权限混淆 |
 | 都在 K8s 集群内、同一 Keycloak Realm | 可共用 | 降低部署复杂度 |
 
-共用时的注意事项：`--cookie-domain` 设置为 `.example.com`（前面带点号），`--cookie-secret` 保持一致。具体配置参考 [Keycloak + oauth2-proxy 集成实战]({{< relref "../solution-blogs/keycloak-oauth2-proxy" >}})。
+共用时的注意事项：显式设置 `--cookie-domain=example.com`（写成 `.example.com` 也可以；RFC 6265 会忽略前导点号），让 Cookie 覆盖所有应用；`--cookie-secret` 保持一致。省略 `--cookie-domain` 才会得到只对当前主机生效的 host-only Cookie。具体配置参考 [Keycloak + oauth2-proxy 集成实战]({{< relref "../solution-blogs/keycloak-oauth2-proxy" >}})。
 
 ### Q5：SSO 和零信任 IAM 矛盾吗？
 

--- a/content/docs/keycloak/integrations/index.md
+++ b/content/docs/keycloak/integrations/index.md
@@ -180,7 +180,7 @@ spec:
 |-------------|----------|----------|
 | `expected audience` / `invalid aud`，日志里只有 `account` | oauth2-proxy 校验的 ID Token `aud` 没有包含其 `client_id` | 在 Keycloak Client 增加 **Audience mapper**，至少勾选 **Add to ID token**，把 `Included Client Audience` 设为 `oauth2-proxy`；只有后端确实验证 Access Token 时才额外勾选 **Add to access token**。也可在 oauth2-proxy 显式配置 `--oidc-extra-audience`，但不要用它掩盖错误的 Token 受众。 |
 | 登录后反复跳转 / `csrf cookie not found` | `redirect_url`、Ingress `auth-signin`、Cookie Domain / SameSite 与实际访问域名不一致 | `redirect_url` 固定为外部入口 `https://app.example.com/oauth2/callback`；Ingress 使用 `$host` 与 `$escaped_request_uri`；跨子域共享时再设置 `--cookie-domain=.example.com`。 |
-| `/oauth2/auth` 返回 401，但用户已登录 | 业务 Ingress 没把认证响应头传给后端，或 oauth2-proxy 未开启 header 输出 | oauth2-proxy 开启 `--set-xauthrequest=true`；NGINX Ingress 用 `auth-response-headers` 透传 `X-Auth-Request-User`、`X-Auth-Request-Email`、`X-Auth-Request-Groups`。 |
+| `/oauth2/auth` 返回 401，但用户已登录 | 业务 Ingress 没把认证响应头传给后端，或 oauth2-proxy 未开启 header 输出 | oauth2-proxy 开启 `--set-xauthrequest=true`；NGINX Ingress 用 `auth-response-headers` 透传 `X-Auth-Request-User`、`X-Auth-Request-Email`、`X-Auth-Request-Groups`。若后端确实需要 Bearer Token，另行配置 `--pass-access-token=true`，并确认入口复制的是 `X-Auth-Request-Access-Token`；不要把 `--pass-authorization-header`（代理直接转发给其 upstream）误当成 `auth_request` 响应头。 |
 | Keycloak 回调到 `http://` 或错误 host | Keycloak / oauth2-proxy 后面有反向代理，但 `X-Forwarded-*` 头或 proxy 配置缺失 | 入口层保留 `X-Forwarded-Proto`、`X-Forwarded-Host`；Keycloak 侧按生产反向代理章节配置 hostname/proxy headers。 |
 | Keycloak 17+ 后 issuer 不匹配 | 仍沿用旧 WildFly 路径 `/auth/realms/<realm>` | 新部署默认使用 `https://kc.example.com/realms/<realm>`；只有旧版本或保留兼容路径时才使用 `/auth/realms/<realm>`。 |
 

--- a/content/docs/solution-blogs/traefik-forwardauth-keycloak.md
+++ b/content/docs/solution-blogs/traefik-forwardauth-keycloak.md
@@ -410,7 +410,7 @@ curl -sS -o /dev/null -w "%{http_code}" https://grafana.example.com/oauth2/callb
 | oauth2-proxy 日志报 `invalid_token: token contains an invalid number of segments` | ID Token 格式异常或 issuer URL 不匹配 | 确认 `--oidc-issuer-url` 末尾不带斜杠，且与 Keycloak `.well-known/openid-configuration` 返回的 issuer 完全一致 |
 | 登录成功但后端收不到 X-Auth-Request-* 头 | ForwardAuth 中间件未配置 `authResponseHeaders` | 检查 Middleware CRD 的 `spec.forwardAuth.authResponseHeaders` 列表是否包含需要的 header |
 | `/oauth2/callback` 返回 404 | IngressRoute 未正确路由 callback 路径到 oauth2-proxy | 确保有一条 IngressRoute 规则将 `oauth2.example.com`（或应用域名下的 `/oauth2/*`）路由到 oauth2-proxy Service，且该路由**不经过** ForwardAuth 中间件 |
-| 多个应用间频繁要求重新登录 | Cookie Domain 未覆盖全部应用域名 | `--cookie-domain=.example.com` 必须是 `.example.com`（带前导点号），确保所有 `*.example.com` 子域共享 Cookie |
+| 多个应用间频繁要求重新登录 | 未显式设置覆盖全部应用的父域，或 Cookie 的 Path/Secure/SameSite 被错误覆盖 | 设置 `--cookie-domain=example.com`（`.example.com` 也可以；RFC 6265 会忽略前导点号），确保所有 `*.example.com` 子域匹配；不要把“带点号”当成关键条件 |
 
 ### 诊断命令速查
 


### PR DESCRIPTION
## Summary
- Correct the oauth2-proxy subdomain-cookie troubleshooting guidance.
- Explain that RFC 6265 ignores a leading dot in `Domain`; the important distinction is explicit parent-domain scope versus a host-only cookie when `Domain` is omitted.
- Add the same boundary to SSO and Traefik ForwardAuth guidance.

## Changed files
- `content/docs/solution-blogs/oauth2-proxy-common-errors.md` (already present on the branch baseline; this PR's incremental clarification is reflected in the branch history)
- `content/docs/core-capabilities/sso-single-sign-on.md`
- `content/docs/solution-blogs/traefik-forwardauth-keycloak.md`

## Technical sources
- RFC 6265, Domain attribute: https://www.rfc-editor.org/rfc/rfc6265#section-4.1.2.3
- oauth2-proxy configuration overview: https://oauth2-proxy.github.io/oauth2-proxy/configuration/overview

## SEO/GEO impact
Improves the answer to the IAM/OAuth2-proxy subdomain SSO troubleshooting query by removing a misleading “leading dot is required” rule and making the verifiable cookie-scope check explicit.

## Validation
- `npm ci`
- `npm run build` passed with Hugo 0.165.0 extended and Node v26.3.0.
- `git diff --check` passed.
- Existing Hugo warnings remain: deprecated `css.Sass` and short descriptions on generated taxonomy pages.

## Risk/rollback
Documentation-only, no runtime behavior change. Revert the squash commit if the wording needs to be rolled back.